### PR TITLE
Add WebGPU render command batching

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.debugging.pure.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.debugging.pure.ts
@@ -107,6 +107,11 @@ export function RegisterWebGPUDebugging(): void {
             return;
         }
 
+        if (this._currentRenderPass) {
+            // Record batched draws before opening the group so they stay attributed to the enclosing scope.
+            this._flushRenderPassCommands();
+        }
+
         const debugCommands = this._currentRenderPass ?? this._renderEncoder;
 
         debugCommands.pushDebugGroup(groupName);
@@ -127,6 +132,11 @@ export function RegisterWebGPUDebugging(): void {
     WebGPUEngine.prototype._debugPopGroup = function (): void {
         if (!this._enableGPUDebugMarkers) {
             return;
+        }
+
+        if (this._currentRenderPass) {
+            // Record batched draws before closing the group so they stay attributed to it.
+            this._flushRenderPassCommands();
         }
 
         const debugCommands = this._currentRenderPass ?? this._renderEncoder;
@@ -177,6 +187,11 @@ export function RegisterWebGPUDebugging(): void {
     WebGPUEngine.prototype._debugInsertMarker = function (text: string): void {
         if (!this._enableGPUDebugMarkers) {
             return;
+        }
+
+        if (this._currentRenderPass) {
+            // Keep the marker positioned after the draws that were issued before it.
+            this._flushRenderPassCommands();
         }
 
         const debugCommands = this._currentRenderPass ?? this._renderEncoder;

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.query.pure.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.query.pure.ts
@@ -51,6 +51,8 @@ export function RegisterEnginesWebGPUExtensionsEngineQuery(): void {
     ThinWebGPUEngine.prototype.beginOcclusionQuery = function (algorithmType: number, query: OcclusionQuery): boolean {
         if (this.compatibilityMode) {
             if (this._occlusionQuery.canBeginQuery(query as number)) {
+                // Batched draws issued before the query must not be counted by it.
+                this._flushRenderPassCommands();
                 this._currentRenderPass?.beginOcclusionQuery(query as number);
                 return true;
             }
@@ -64,6 +66,9 @@ export function RegisterEnginesWebGPUExtensionsEngineQuery(): void {
 
     ThinWebGPUEngine.prototype.endOcclusionQuery = function (): ThinWebGPUEngine {
         if (this.compatibilityMode) {
+            // Batched draws issued while the query was open must be recorded inside it, otherwise the
+            // query reports zero samples and the mesh is wrongly considered occluded.
+            this._flushRenderPassCommands();
             this._currentRenderPass?.endOcclusionQuery();
         } else {
             this._bundleList.addItem(new WebGPURenderItemEndOcclusionQuery());

--- a/packages/dev/core/src/Engines/WebGPU/webgpuRenderPassCommandStream.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuRenderPassCommandStream.ts
@@ -82,6 +82,8 @@ export interface IWebGPURenderPassCommandRecorderProvider {
     /**
      * Returns the host handle id for a backend resource (pipeline, buffer or bind group), or 0 when
      * the resource has no host handle (which makes the draw fall back to direct encoder calls).
+     * Ids must be positive safe integers (at most Number.MAX_SAFE_INTEGER) so they encode losslessly
+     * into 64-bit command words; out-of-range ids are treated as missing.
      * @param resource the backend resource to identify
      */
     getResourceId(resource: Nullable<object>): number;
@@ -244,6 +246,10 @@ export class WebGPURenderPassCommandStream {
         this.reset();
 
         if (!success) {
+            // The encoded words cannot be replayed (commands are consumed as they are encoded, which is
+            // what keeps the draw path allocation-free), so the draws in this batch are dropped from the
+            // current frame. A recording failure past the protocol-version handshake indicates a broken
+            // host decoder, so log once and fall back permanently to direct encoder calls.
             const lastError = this._options.getProvider()?.getLastError?.();
             const detail = lastError && lastError.length > 0 ? `: ${lastError}` : "";
             this._disable(`WebGPU render pass command stream recording failed${detail}. The draws batched for this flush were dropped.`);
@@ -287,13 +293,13 @@ export class WebGPURenderPassCommandStream {
             return false;
         }
 
-        const pipelineId = provider.getResourceId(command.pipeline);
+        const pipelineId = this._getValidResourceId(provider, command.pipeline);
         if (pipelineId === 0) {
             return false;
         }
 
         const isIndexedDraw = command.drawKind === WebGPURenderPassDrawKind.INDEXED;
-        const indexBufferId = isIndexedDraw ? provider.getResourceId(command.indexBuffer.underlyingResource) : 0;
+        const indexBufferId = isIndexedDraw ? this._getValidResourceId(provider, command.indexBuffer.underlyingResource) : 0;
         if (isIndexedDraw && indexBufferId === 0) {
             return false;
         }
@@ -309,7 +315,7 @@ export class WebGPURenderPassCommandStream {
                 continue;
             }
 
-            const bufferId = provider.getResourceId(buffer.underlyingResource);
+            const bufferId = this._getValidResourceId(provider, buffer.underlyingResource);
             if (bufferId === 0) {
                 return false;
             }
@@ -319,14 +325,14 @@ export class WebGPURenderPassCommandStream {
 
         const bindGroupIds = this._scratchBindGroupIds;
         for (let i = 0; i < command.bindGroups.length; i++) {
-            const bindGroupId = provider.getResourceId(command.bindGroups[i]);
+            const bindGroupId = this._getValidResourceId(provider, command.bindGroups[i]);
             if (bindGroupId === 0) {
                 return false;
             }
             bindGroupIds[i] = bindGroupId;
         }
 
-        const indirectDrawBufferId = command.indirectDrawBuffer ? provider.getResourceId(command.indirectDrawBuffer) : 0;
+        const indirectDrawBufferId = command.indirectDrawBuffer ? this._getValidResourceId(provider, command.indirectDrawBuffer) : 0;
         if (command.indirectDrawBuffer && indirectDrawBufferId === 0) {
             return false;
         }
@@ -407,6 +413,12 @@ export class WebGPURenderPassCommandStream {
 
         this._drawCount++;
         return true;
+    }
+
+    private _getValidResourceId(provider: IWebGPURenderPassCommandRecorderProvider, resource: Nullable<object>): number {
+        const id = provider.getResourceId(resource);
+        // Ids are encoded into u64 command words from a JS number: reject ids that cannot round-trip exactly.
+        return id > 0 && Number.isSafeInteger(id) ? id : 0;
     }
 
     private _disable(message: string): void {

--- a/packages/dev/core/src/Engines/WebGPU/webgpuRenderPassCommandStream.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuRenderPassCommandStream.ts
@@ -1,0 +1,449 @@
+/**
+ * Render-pass command-stream lowering for hosts where each WebGPU encoder call crosses a JS/native
+ * boundary (e.g. BabylonNative over wgpu-native). This is the WebGPU counterpart of the
+ * CommandBufferEncoder + NativeDataStream pairing used by the bgfx-based NativeEngine (see
+ * thinNativeEngine.pure.ts): commands are encoded as words into a reused buffer and submitted across
+ * the bridge in batches, guarded by a protocol-version handshake against JS/native drift. The
+ * conduits necessarily differ: WebGPUEngine also ships to browsers, so the host contract is injected
+ * (IWebGPURenderPassCommandRecorderProvider) rather than read from the _native global, command
+ * tokens are protocol integers rather than native-provided handles, and commands carry WebGPU
+ * render-pass semantics (pipelines, bind groups, draws) referencing host resource-handle ids.
+ */
+import { type VertexBuffer } from "../../Buffers/buffer.pure";
+import { type DataBuffer } from "../../Buffers/dataBuffer";
+import { Logger } from "../../Misc/logger";
+import { type Nullable } from "../../types";
+import * as WebGPUConstants from "./webgpuConstants";
+
+/**
+ * Version of the render-pass command-stream encoding. The host decoder reports the version it was
+ * built against through IWebGPURenderPassCommandRecorderProvider.protocolVersion; when the versions
+ * differ, the stream disables itself and draws fall back to direct encoder calls. This mirrors the
+ * PROTOCOL_VERSION guard of the bgfx-based NativeEngine, soft-failing instead of throwing because
+ * this path is an optimization rather than the engine's only transport. Bump it whenever opcodes or
+ * command layouts change.
+ */
+export const WebGPURenderPassCommandStreamProtocolVersion = 1;
+
+/** @internal */
+export const WebGPURenderPassCommandOpcode = {
+    setPipeline: 1,
+    setBindGroup: 2,
+    setVertexBuffer: 3,
+    setIndexBuffer: 4,
+    draw: 9,
+    drawIndexed: 10,
+    drawIndirect: 11,
+    drawIndexedIndirect: 12,
+} as const;
+
+/** @internal */
+export const WebGPURenderPassDrawKind = {
+    INDEXED: 0,
+    NON_INDEXED: 1,
+} as const;
+
+/** @internal */
+export type WebGPURenderPassDrawKind = (typeof WebGPURenderPassDrawKind)[keyof typeof WebGPURenderPassDrawKind];
+
+const DefaultBufferOffset = 0;
+const DefaultBaseVertex = 0;
+const DefaultFirstInstance = 0;
+const NoDynamicOffsets = 0;
+
+/**
+ * Render pass encoder extended with an optional host recording hook.
+ * The recorder must consume the command words synchronously: the buffer is owned by the stream and
+ * is reused as soon as the call returns.
+ * @internal
+ */
+export interface IWebGPUCommandRecordingRenderPass extends GPURenderPassEncoder {
+    _recordCommands?: (commands: Uint32Array, drawCount: number, multiDrawCallCount: number, multiDrawDrawCount: number, wordCount: number) => boolean;
+}
+
+/**
+ * Contract implemented by hosts whose WebGPU backend can record batched render-pass command streams
+ * (e.g. BabylonNative over wgpu-native, where every render-pass encoder call crosses the JS/native
+ * boundary). Install an implementation through WebGPUEngine.renderPassCommandRecorderProvider to let
+ * compatibility-mode draws be encoded into a command stream and submitted in batches instead of one
+ * encoder call per state change and draw.
+ */
+export interface IWebGPURenderPassCommandRecorderProvider {
+    /**
+     * The command-stream protocol version the host decoder was built against (see
+     * WebGPURenderPassCommandStreamProtocolVersion). A mismatch permanently disables the stream for
+     * the engine and draws fall back to direct encoder calls.
+     */
+    protocolVersion: number;
+    /**
+     * Returns true while command-stream recording is enabled on the host.
+     */
+    isEnabled(): boolean;
+    /**
+     * Returns the host handle id for a backend resource (pipeline, buffer or bind group), or 0 when
+     * the resource has no host handle (which makes the draw fall back to direct encoder calls).
+     * @param resource the backend resource to identify
+     */
+    getResourceId(resource: Nullable<object>): number;
+    /**
+     * Optionally returns the host's last backend error, used to enrich diagnostics when recording fails.
+     */
+    getLastError?(): string | undefined;
+}
+
+/** @internal */
+interface IWebGPURenderPassDrawCommandBase {
+    renderPass: GPURenderPassEncoder | GPURenderBundleEncoder;
+    drawKind: WebGPURenderPassDrawKind;
+    pipeline: GPURenderPipeline;
+    bindGroups: GPUBindGroup[];
+    vertexBuffers: VertexBuffer[];
+    count: number;
+    instancesCount: number;
+    start: number;
+    indirectDrawBuffer: Nullable<GPUBuffer>;
+}
+
+/** @internal */
+export interface IWebGPURenderPassIndexedDrawCommand extends IWebGPURenderPassDrawCommandBase {
+    drawKind: typeof WebGPURenderPassDrawKind.INDEXED;
+    indexBuffer: DataBuffer;
+    indexFormat: GPUIndexFormat;
+}
+
+/** @internal */
+export interface IWebGPURenderPassNonIndexedDrawCommand extends IWebGPURenderPassDrawCommandBase {
+    drawKind: typeof WebGPURenderPassDrawKind.NON_INDEXED;
+    indexBuffer: null;
+    indexFormat: null;
+}
+
+/**
+ * Draw commands are consumed synchronously by both the lowering and the replay paths, so callers may
+ * (and the engine does) reuse a single command instance across draws to keep the hot path allocation-free.
+ * @internal
+ */
+export type IWebGPURenderPassDrawCommand = IWebGPURenderPassIndexedDrawCommand | IWebGPURenderPassNonIndexedDrawCommand;
+
+/**
+ * Creates a reusable indexed draw command. Every field must be (re)assigned before each submission.
+ * @internal
+ */
+export function CreateWebGPURenderPassIndexedDrawCommand(): IWebGPURenderPassIndexedDrawCommand {
+    return {
+        renderPass: null as unknown as GPURenderPassEncoder,
+        drawKind: WebGPURenderPassDrawKind.INDEXED,
+        pipeline: null as unknown as GPURenderPipeline,
+        bindGroups: [],
+        vertexBuffers: [],
+        indexBuffer: null as unknown as DataBuffer,
+        indexFormat: WebGPUConstants.IndexFormat.Uint32,
+        count: 0,
+        instancesCount: 0,
+        start: 0,
+        indirectDrawBuffer: null,
+    };
+}
+
+/**
+ * Creates a reusable non-indexed draw command. Every field must be (re)assigned before each submission.
+ * @internal
+ */
+export function CreateWebGPURenderPassNonIndexedDrawCommand(): IWebGPURenderPassNonIndexedDrawCommand {
+    return {
+        renderPass: null as unknown as GPURenderPassEncoder,
+        drawKind: WebGPURenderPassDrawKind.NON_INDEXED,
+        pipeline: null as unknown as GPURenderPipeline,
+        bindGroups: [],
+        vertexBuffers: [],
+        indexBuffer: null,
+        indexFormat: null,
+        count: 0,
+        instancesCount: 0,
+        start: 0,
+        indirectDrawBuffer: null,
+    };
+}
+
+/** @internal */
+export interface IWebGPURenderPassCommandStreamOptions {
+    getProvider: () => Nullable<IWebGPURenderPassCommandRecorderProvider>;
+}
+
+/** @internal */
+export function ApplyWebGPURenderPassDrawCommand(command: IWebGPURenderPassDrawCommand): void {
+    const renderPass = command.renderPass;
+    const isIndexedDraw = command.drawKind === WebGPURenderPassDrawKind.INDEXED;
+
+    renderPass.setPipeline(command.pipeline);
+
+    if (isIndexedDraw) {
+        renderPass.setIndexBuffer(command.indexBuffer.underlyingResource, command.indexFormat, DefaultBufferOffset);
+    }
+
+    for (let index = 0; index < command.vertexBuffers.length; index++) {
+        const vertexBuffer = command.vertexBuffers[index];
+        const buffer = vertexBuffer.effectiveBuffer;
+        if (buffer) {
+            renderPass.setVertexBuffer(index, buffer.underlyingResource, vertexBuffer._validOffsetRange ? 0 : vertexBuffer.byteOffset);
+        }
+    }
+
+    for (let i = 0; i < command.bindGroups.length; i++) {
+        renderPass.setBindGroup(i, command.bindGroups[i]);
+    }
+
+    if (command.indirectDrawBuffer) {
+        if (isIndexedDraw) {
+            renderPass.drawIndexedIndirect(command.indirectDrawBuffer, DefaultBufferOffset);
+        } else {
+            renderPass.drawIndirect(command.indirectDrawBuffer, DefaultBufferOffset);
+        }
+    } else if (isIndexedDraw) {
+        renderPass.drawIndexed(command.count, command.instancesCount || 1, command.start, DefaultBaseVertex, DefaultFirstInstance);
+    } else {
+        renderPass.draw(command.count, command.instancesCount || 1, command.start, DefaultFirstInstance);
+    }
+}
+
+/** @internal */
+export class WebGPURenderPassCommandStream {
+    private _commandWords = new Uint32Array(256);
+    private _commandWordCount = 0;
+    private _drawCount = 0;
+    private _renderPass: Nullable<GPURenderPassEncoder | GPURenderBundleEncoder> = null;
+    private _pipelineId = 0;
+    private _indexBufferId = 0;
+    private _indexFormat: Nullable<GPUIndexFormat> = null;
+    private _vertexBufferIds: number[] = [];
+    private _vertexBufferOffsets: number[] = [];
+    private _bindGroupIds: number[] = [];
+    private _scratchVertexBufferIds: number[] = [];
+    private _scratchVertexBufferOffsets: number[] = [];
+    private _scratchBindGroupIds: number[] = [];
+    private _disabledAfterFailure = false;
+
+    public constructor(private readonly _options: IWebGPURenderPassCommandStreamOptions) {}
+
+    public flush(): boolean {
+        const renderPass = this._renderPass;
+        const wordCount = this._commandWordCount;
+        if (!renderPass || wordCount === 0) {
+            // Nothing is pending: keep this path free of any work so disabled engines pay nothing per draw.
+            return false;
+        }
+
+        const recordCommands = (renderPass as IWebGPUCommandRecordingRenderPass)._recordCommands;
+        if (typeof recordCommands !== "function") {
+            this.reset();
+            this._disable("WebGPU render pass command stream cannot flush: the active render pass does not support command recording.");
+            return false;
+        }
+
+        const success = recordCommands.call(renderPass, this._commandWords, this._drawCount, 0, 0, wordCount) === true;
+        this.reset();
+
+        if (!success) {
+            const lastError = this._options.getProvider()?.getLastError?.();
+            const detail = lastError && lastError.length > 0 ? `: ${lastError}` : "";
+            this._disable(`WebGPU render pass command stream recording failed${detail}. The draws batched for this flush were dropped.`);
+            return false;
+        }
+
+        return true;
+    }
+
+    public reset(): void {
+        this._commandWordCount = 0;
+        this._drawCount = 0;
+        this._renderPass = null;
+        this._pipelineId = 0;
+        this._indexBufferId = 0;
+        this._indexFormat = null;
+        this._vertexBufferIds.length = 0;
+        this._vertexBufferOffsets.length = 0;
+        this._bindGroupIds.length = 0;
+    }
+
+    public tryAppend(command: IWebGPURenderPassDrawCommand): boolean {
+        if (this._disabledAfterFailure) {
+            return false;
+        }
+
+        const provider = this._options.getProvider();
+        if (!provider || !provider.isEnabled()) {
+            return false;
+        }
+
+        if (provider.protocolVersion !== WebGPURenderPassCommandStreamProtocolVersion) {
+            this._disable(
+                `WebGPU render pass command stream protocol mismatch: the host decoder reports version ${provider.protocolVersion} but the engine encodes version ${WebGPURenderPassCommandStreamProtocolVersion}.`
+            );
+            return false;
+        }
+
+        const recordCommands = (command.renderPass as IWebGPUCommandRecordingRenderPass)._recordCommands;
+        if (typeof recordCommands !== "function") {
+            return false;
+        }
+
+        const pipelineId = provider.getResourceId(command.pipeline);
+        if (pipelineId === 0) {
+            return false;
+        }
+
+        const isIndexedDraw = command.drawKind === WebGPURenderPassDrawKind.INDEXED;
+        const indexBufferId = isIndexedDraw ? provider.getResourceId(command.indexBuffer.underlyingResource) : 0;
+        if (isIndexedDraw && indexBufferId === 0) {
+            return false;
+        }
+
+        const vertexBufferIds = this._scratchVertexBufferIds;
+        const vertexBufferOffsets = this._scratchVertexBufferOffsets;
+        for (let index = 0; index < command.vertexBuffers.length; index++) {
+            const vertexBuffer = command.vertexBuffers[index];
+            const buffer = vertexBuffer.effectiveBuffer;
+            if (!buffer) {
+                vertexBufferIds[index] = 0;
+                vertexBufferOffsets[index] = 0;
+                continue;
+            }
+
+            const bufferId = provider.getResourceId(buffer.underlyingResource);
+            if (bufferId === 0) {
+                return false;
+            }
+            vertexBufferIds[index] = bufferId;
+            vertexBufferOffsets[index] = vertexBuffer._validOffsetRange ? 0 : vertexBuffer.byteOffset;
+        }
+
+        const bindGroupIds = this._scratchBindGroupIds;
+        for (let i = 0; i < command.bindGroups.length; i++) {
+            const bindGroupId = provider.getResourceId(command.bindGroups[i]);
+            if (bindGroupId === 0) {
+                return false;
+            }
+            bindGroupIds[i] = bindGroupId;
+        }
+
+        const indirectDrawBufferId = command.indirectDrawBuffer ? provider.getResourceId(command.indirectDrawBuffer) : 0;
+        if (command.indirectDrawBuffer && indirectDrawBufferId === 0) {
+            return false;
+        }
+
+        if (this._renderPass && this._renderPass !== command.renderPass) {
+            this.flush();
+            if (this._disabledAfterFailure) {
+                return false;
+            }
+        }
+
+        this._renderPass = command.renderPass;
+        if (this._pipelineId !== pipelineId) {
+            this._pushU32(WebGPURenderPassCommandOpcode.setPipeline);
+            this._pushU64(pipelineId);
+            this._pipelineId = pipelineId;
+        }
+
+        if (isIndexedDraw) {
+            if (this._indexBufferId !== indexBufferId || this._indexFormat !== command.indexFormat) {
+                this._pushU32(WebGPURenderPassCommandOpcode.setIndexBuffer);
+                this._pushU64(indexBufferId);
+                this._pushU32(command.indexFormat === WebGPUConstants.IndexFormat.Uint32 ? 1 : 0);
+                this._pushU64(DefaultBufferOffset);
+                this._pushU64Max();
+                this._indexBufferId = indexBufferId;
+                this._indexFormat = command.indexFormat;
+            }
+        }
+
+        for (let index = 0; index < command.vertexBuffers.length; index++) {
+            const bufferId = vertexBufferIds[index];
+            if (!bufferId) {
+                continue;
+            }
+
+            const offset = vertexBufferOffsets[index];
+            if (this._vertexBufferIds[index] !== bufferId || this._vertexBufferOffsets[index] !== offset) {
+                this._pushU32(WebGPURenderPassCommandOpcode.setVertexBuffer);
+                this._pushU32(index);
+                this._pushU64(bufferId);
+                this._pushU64(offset);
+                this._pushU64Max();
+                this._vertexBufferIds[index] = bufferId;
+                this._vertexBufferOffsets[index] = offset;
+            }
+        }
+
+        for (let i = 0; i < command.bindGroups.length; i++) {
+            const bindGroupId = bindGroupIds[i];
+            if (this._bindGroupIds[i] !== bindGroupId) {
+                this._pushU32(WebGPURenderPassCommandOpcode.setBindGroup);
+                this._pushU32(i);
+                this._pushU64(bindGroupId);
+                this._pushU32(NoDynamicOffsets);
+                this._bindGroupIds[i] = bindGroupId;
+            }
+        }
+
+        if (command.indirectDrawBuffer) {
+            this._pushU32(isIndexedDraw ? WebGPURenderPassCommandOpcode.drawIndexedIndirect : WebGPURenderPassCommandOpcode.drawIndirect);
+            this._pushU64(indirectDrawBufferId);
+            this._pushU64(DefaultBufferOffset);
+        } else if (isIndexedDraw) {
+            this._pushU32(WebGPURenderPassCommandOpcode.drawIndexed);
+            this._pushU32(command.count);
+            this._pushU32(command.instancesCount || 1);
+            this._pushU32(command.start);
+            this._pushU32(DefaultBaseVertex);
+            this._pushU32(DefaultFirstInstance);
+        } else {
+            this._pushU32(WebGPURenderPassCommandOpcode.draw);
+            this._pushU32(command.count);
+            this._pushU32(command.instancesCount || 1);
+            this._pushU32(command.start);
+            this._pushU32(DefaultFirstInstance);
+        }
+
+        this._drawCount++;
+        return true;
+    }
+
+    private _disable(message: string): void {
+        this._disabledAfterFailure = true;
+        Logger.Error(`${message} Subsequent draws fall back to direct encoder calls.`);
+    }
+
+    private _ensureCapacity(additionalWords: number): void {
+        const requiredWords = this._commandWordCount + additionalWords;
+        if (requiredWords <= this._commandWords.length) {
+            return;
+        }
+
+        let capacity = this._commandWords.length;
+        while (capacity < requiredWords) {
+            capacity *= 2;
+        }
+        const commands = new Uint32Array(capacity);
+        commands.set(this._commandWords.subarray(0, this._commandWordCount));
+        this._commandWords = commands;
+    }
+
+    private _pushU32(value: number): void {
+        this._ensureCapacity(1);
+        this._commandWords[this._commandWordCount++] = value >>> 0;
+    }
+
+    private _pushU64(value: number): void {
+        const normalized = Number.isFinite(value) && value > 0 ? value : 0;
+        this._ensureCapacity(2);
+        this._commandWords[this._commandWordCount++] = normalized >>> 0;
+        this._commandWords[this._commandWordCount++] = Math.floor(normalized / 0x100000000) >>> 0;
+    }
+
+    private _pushU64Max(): void {
+        this._ensureCapacity(2);
+        this._commandWords[this._commandWordCount++] = 0xffffffff;
+        this._commandWords[this._commandWordCount++] = 0xffffffff;
+    }
+}

--- a/packages/dev/core/src/Engines/pure.ts
+++ b/packages/dev/core/src/Engines/pure.ts
@@ -42,5 +42,6 @@ export * from "./Processors/iShaderProcessor";
 export * from "./engine.common";
 export * from "./engineRegistration.pure";
 export * from "./nullEngineRegistration.pure";
+export * from "./renderCommandBatcher.pure";
 export * from "./Processors/pure";
 export * from "./WebGPU/pure";

--- a/packages/dev/core/src/Engines/renderCommandBatcher.pure.ts
+++ b/packages/dev/core/src/Engines/renderCommandBatcher.pure.ts
@@ -1,0 +1,35 @@
+/** This file must only contain pure code and pure imports */
+
+/** @internal */
+export interface IRenderCommandLowering<Command> {
+    tryAppend(command: Command): boolean;
+    flush(): boolean;
+    reset(): void;
+}
+
+/** @internal */
+export class RenderCommandBatcher<Command> {
+    public constructor(
+        private readonly _lowering: IRenderCommandLowering<Command> | null | undefined,
+        private readonly _replay: (command: Command) => void
+    ) {}
+
+    public submit(command: Command): boolean {
+        const lowering = this._lowering;
+        if (lowering?.tryAppend(command)) {
+            return true;
+        }
+
+        lowering?.flush();
+        this._replay(command);
+        return false;
+    }
+
+    public flush(): boolean {
+        return this._lowering?.flush() ?? false;
+    }
+
+    public reset(): void {
+        this._lowering?.reset();
+    }
+}

--- a/packages/dev/core/src/Engines/thinWebGPUEngine.ts
+++ b/packages/dev/core/src/Engines/thinWebGPUEngine.ts
@@ -94,12 +94,24 @@ export abstract class ThinWebGPUEngine extends AbstractEngine {
         return this._currentRenderTarget === null;
     }
 
+    /**
+     * Submits any render-pass commands that were batched for deferred recording. This must be called
+     * before mutating the current render pass directly (occlusion queries, debug markers, dynamic
+     * state, pass end) so that batched draws keep their position relative to those commands.
+     * No-op for engines that do not batch render-pass commands.
+     * @internal
+     */
+    public _flushRenderPassCommands(): void {
+        // Overridden by engines that batch render-pass command submission.
+    }
+
     /** @internal */
     public _endCurrentRenderPass(): number {
         if (!this._currentRenderPass) {
             return 0;
         }
 
+        this._flushRenderPassCommands();
         this._debugPopBeforeEndOfEncoder();
 
         const currentPassIndex = this._currentPassIsMainPass() ? 2 : 1;

--- a/packages/dev/core/src/Engines/webgpuEngine.pure.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.pure.ts
@@ -79,8 +79,18 @@ import { PerfCounter } from "../Misc/perfCounter";
 import { resetCachedPipeline } from "../Materials/effect.functions";
 import { RegisterAbstractEngineDom } from "./AbstractEngine/abstractEngine.dom.pure";
 import { RegisterAbstractEngineRenderPass } from "./AbstractEngine/abstractEngine.renderPass.pure";
+import { RenderCommandBatcher } from "./renderCommandBatcher.pure";
 
 import { WebGPUExternalTexture } from "./WebGPU/webgpuExternalTexture";
+import {
+    ApplyWebGPURenderPassDrawCommand,
+    CreateWebGPURenderPassIndexedDrawCommand,
+    CreateWebGPURenderPassNonIndexedDrawCommand,
+    type IWebGPURenderPassCommandRecorderProvider,
+    type IWebGPURenderPassDrawCommand,
+    WebGPURenderPassCommandStream,
+    WebGPURenderPassDrawKind,
+} from "./WebGPU/webgpuRenderPassCommandStream";
 import { type TextureSampler } from "../Materials/Textures/textureSampler";
 import { type StorageBuffer } from "../Buffers/storageBuffer";
 
@@ -406,10 +416,35 @@ export class WebGPUEngine extends ThinWebGPUEngine {
     private _currentVertexBuffers: { [key: string]: Nullable<VertexBuffer> } = {};
     private _currentOverrideVertexBuffers: Nullable<{ [key: string]: Nullable<VertexBuffer> }> = null;
     private _currentIndexBuffer: Nullable<DataBuffer> = null;
+    private _renderPassCommandRecorderProvider: Nullable<IWebGPURenderPassCommandRecorderProvider> = null;
+    private _renderPassCommandLowering = new WebGPURenderPassCommandStream({
+        getProvider: () => this._renderPassCommandRecorderProvider,
+    });
+    private _renderPassDrawBatcher = new RenderCommandBatcher<IWebGPURenderPassDrawCommand>(this._renderPassCommandLowering, ApplyWebGPURenderPassDrawCommand);
+    private readonly _scratchIndexedDrawCommand = CreateWebGPURenderPassIndexedDrawCommand();
+    private readonly _scratchNonIndexedDrawCommand = CreateWebGPURenderPassNonIndexedDrawCommand();
     private _dummyIndexBuffer: WebGPUDataBuffer;
     private _colorWriteLocal = true;
     private _forceEnableEffect = false;
     private _internalFrameCounter = 0;
+
+    /**
+     * Gets or sets the provider that lets the host lower render-pass draw submission into a batched
+     * command stream (see IWebGPURenderPassCommandRecorderProvider). Hosts such as BabylonNative,
+     * where every render-pass encoder call crosses the JS/native boundary, install a provider to
+     * amortize that cost across many draws — the same pattern the bgfx-based NativeEngine uses with
+     * its CommandBufferEncoder. When no provider is set (the default, and always the case in
+     * browsers), draws are submitted through the standard WebGPU encoder calls.
+     */
+    public get renderPassCommandRecorderProvider(): Nullable<IWebGPURenderPassCommandRecorderProvider> {
+        return this._renderPassCommandRecorderProvider;
+    }
+
+    public set renderPassCommandRecorderProvider(provider: Nullable<IWebGPURenderPassCommandRecorderProvider>) {
+        // Record anything batched under the previous provider before swapping contracts.
+        this._flushRenderPassCommands();
+        this._renderPassCommandRecorderProvider = provider;
+    }
 
     /**
      * Gets or sets the snapshot rendering mode
@@ -1330,6 +1365,11 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         return this._currentRenderTarget ? this._rttRenderPassWrapper : this._mainRenderPassWrapper;
     }
 
+    /** @internal */
+    public override _flushRenderPassCommands(): void {
+        this._renderPassDrawBatcher.flush();
+    }
+
     //------------------------------------------------------------------------------
     //                          Static Pipeline WebGPU States
     //------------------------------------------------------------------------------
@@ -1432,6 +1472,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         if (bundleList) {
             bundleList.addItem(new WebGPURenderItemViewport(x, y, w, h));
         } else {
+            this._flushRenderPassCommands();
             this._getCurrentRenderPass().setViewport(x, y, w, h, 0, 1);
         }
     }
@@ -1473,6 +1514,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         if (bundleList) {
             bundleList.addItem(new WebGPURenderItemScissor(this._scissorCached.x, y, this._scissorCached.z, this._scissorCached.w));
         } else {
+            this._flushRenderPassCommands();
             this._getCurrentRenderPass().setScissorRect(this._scissorCached.x, y, this._scissorCached.z, this._scissorCached.w);
         }
     }
@@ -1517,6 +1559,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         if (bundleList) {
             bundleList.addItem(new WebGPURenderItemStencilRef(this._stencilStateComposer.funcRef ?? 0));
         } else {
+            this._flushRenderPassCommands();
             this._getCurrentRenderPass().setStencilReference(this._stencilStateComposer.funcRef ?? 0);
         }
     }
@@ -1546,6 +1589,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         if (bundleList) {
             bundleList.addItem(new WebGPURenderItemBlendColor(this._alphaState._blendConstants.slice()));
         } else {
+            this._flushRenderPassCommands();
             this._getCurrentRenderPass().setBlendConstant(this._alphaState._blendConstants as GPUColor);
         }
     }
@@ -1603,6 +1647,8 @@ export class WebGPUEngine extends ThinWebGPUEngine {
     }
 
     private _clearFullQuad(clearColor?: Nullable<IColor4Like>, clearDepth?: boolean, clearStencil?: boolean): void {
+        this._flushRenderPassCommands();
+
         const renderPass = !this.compatibilityMode ? null : this._getCurrentRenderPass();
 
         this._clearQuad.setColorFormat(this._colorFormat);
@@ -3705,13 +3751,19 @@ export class WebGPUEngine extends ThinWebGPUEngine {
     }
 
     private _applyRenderPassChanges(bundleList: Nullable<WebGPUBundleList>): void {
+        const mustUpdateViewport = this._mustUpdateViewport();
+        const mustUpdateScissor = this._mustUpdateScissor();
         const mustUpdateStencilRef = !this._stencilStateComposer.enabled ? false : this._mustUpdateStencilRef();
         const mustUpdateBlendColor = !this._alphaState.alphaBlend ? false : this._mustUpdateBlendColor();
 
-        if (this._mustUpdateViewport()) {
+        if (mustUpdateViewport || mustUpdateScissor || mustUpdateStencilRef || mustUpdateBlendColor) {
+            this._flushRenderPassCommands();
+        }
+
+        if (mustUpdateViewport) {
             this._applyViewport(bundleList);
         }
-        if (this._mustUpdateScissor()) {
+        if (mustUpdateScissor) {
             this._applyScissor(bundleList);
         }
         if (mustUpdateStencilRef) {
@@ -3722,7 +3774,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         }
     }
 
-    private _draw(drawType: number, fillMode: number, start: number, count: number, instancesCount: number): void {
+    private _draw(drawKind: WebGPURenderPassDrawKind, fillMode: number, start: number, count: number, instancesCount: number): void {
         const renderPass = this._getCurrentRenderPass();
         const bundleList = this._bundleList;
 
@@ -3795,6 +3847,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         const pipeline = this._cacheRenderPipeline.getRenderPipeline(fillMode, this._currentEffect!, this.currentSampleCount, textureState);
 
         const bindGroups = this._cacheBindGroups.getBindGroups(webgpuPipelineContext, this._currentDrawContext, this._currentMaterialContext);
+        const vertexBuffers = this._cacheRenderPipeline.vertexBuffers;
 
         if (!this._snapshotRendering.record) {
             this._applyRenderPassChanges(!this.compatibilityMode ? bundleList : null);
@@ -3808,48 +3861,44 @@ export class WebGPUEngine extends ThinWebGPUEngine {
             }
         }
 
-        // bind pipeline
-        renderPass2.setPipeline(pipeline);
-
-        // bind index/vertex buffers
-        if (this._currentIndexBuffer) {
-            renderPass2.setIndexBuffer(
-                this._currentIndexBuffer.underlyingResource,
-                this._currentIndexBuffer.is32Bits ? WebGPUConstants.IndexFormat.Uint32 : WebGPUConstants.IndexFormat.Uint16,
-                0
-            );
-        }
-
-        const vertexBuffers = this._cacheRenderPipeline.vertexBuffers;
-        for (let index = 0; index < vertexBuffers.length; index++) {
-            const vertexBuffer = vertexBuffers[index];
-
-            const buffer = vertexBuffer.effectiveBuffer;
-            if (buffer) {
-                renderPass2.setVertexBuffer(index, buffer.underlyingResource, vertexBuffer._validOffsetRange ? 0 : vertexBuffer.byteOffset);
-            }
-        }
-
-        // bind bind groups
-        for (let i = 0; i < bindGroups.length; i++) {
-            renderPass2.setBindGroup(i, bindGroups[i]);
-        }
-
-        // draw
         const nonCompatMode = !this.compatibilityMode && !this._snapshotRendering.record;
+        const indirectDrawBuffer =
+            (nonCompatMode || this._currentDrawContext._enableIndirectDrawInCompatMode) && this._currentDrawContext.indirectDrawBuffer
+                ? this._currentDrawContext.indirectDrawBuffer
+                : null;
 
-        if ((nonCompatMode || this._currentDrawContext._enableIndirectDrawInCompatMode) && this._currentDrawContext.indirectDrawBuffer) {
+        if (indirectDrawBuffer) {
             this._currentDrawContext.setIndirectData(count, instancesCount || 1, start);
-            if (drawType === 0) {
-                renderPass2.drawIndexedIndirect(this._currentDrawContext.indirectDrawBuffer, 0);
-            } else {
-                renderPass2.drawIndirect(this._currentDrawContext.indirectDrawBuffer, 0);
-            }
-        } else if (drawType === 0) {
-            renderPass2.drawIndexed(count, instancesCount || 1, start, 0, 0);
-        } else {
-            renderPass2.draw(count, instancesCount || 1, start, 0);
         }
+
+        // Reused scratch commands keep this hot path allocation-free; both the lowering and the
+        // replay paths consume the command synchronously, so the instances never escape this call.
+        let drawCommand: IWebGPURenderPassDrawCommand;
+        if (drawKind === WebGPURenderPassDrawKind.INDEXED) {
+            const indexedDrawCommand = this._scratchIndexedDrawCommand;
+            indexedDrawCommand.indexBuffer = this._currentIndexBuffer!;
+            indexedDrawCommand.indexFormat = this._currentIndexBuffer!.is32Bits ? WebGPUConstants.IndexFormat.Uint32 : WebGPUConstants.IndexFormat.Uint16;
+            drawCommand = indexedDrawCommand;
+        } else {
+            drawCommand = this._scratchNonIndexedDrawCommand;
+        }
+        drawCommand.renderPass = renderPass2;
+        drawCommand.pipeline = pipeline;
+        drawCommand.bindGroups = bindGroups;
+        drawCommand.vertexBuffers = vertexBuffers;
+        drawCommand.count = count;
+        drawCommand.instancesCount = instancesCount;
+        drawCommand.start = start;
+        drawCommand.indirectDrawBuffer = indirectDrawBuffer;
+
+        if (this.compatibilityMode && !this._snapshotRendering.record) {
+            this._renderPassDrawBatcher.submit(drawCommand);
+            this._reportDrawCall();
+            return;
+        }
+
+        this._flushRenderPassCommands();
+        ApplyWebGPURenderPassDrawCommand(drawCommand);
 
         if (nonCompatMode) {
             this._currentDrawContext.fastBundle = (renderPass2 as GPURenderBundleEncoder).finish();
@@ -3867,7 +3916,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
      * @param instancesCount defines the number of instances to draw (if instantiation is enabled)
      */
     public drawElementsType(fillMode: number, indexStart: number, indexCount: number, instancesCount: number = 1): void {
-        this._draw(0, fillMode, indexStart, indexCount, instancesCount);
+        this._draw(WebGPURenderPassDrawKind.INDEXED, fillMode, indexStart, indexCount, instancesCount);
     }
 
     /**
@@ -3879,7 +3928,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
      */
     public drawArraysType(fillMode: number, verticesStart: number, verticesCount: number, instancesCount: number = 1): void {
         this._currentIndexBuffer = null;
-        this._draw(1, fillMode, verticesStart, verticesCount, instancesCount);
+        this._draw(WebGPURenderPassDrawKind.NON_INDEXED, fillMode, verticesStart, verticesCount, instancesCount);
     }
 
     //------------------------------------------------------------------------------

--- a/packages/dev/core/test/unit/Engines/WebGPU/webgpuRenderPassCommandStream.test.ts
+++ b/packages/dev/core/test/unit/Engines/WebGPU/webgpuRenderPassCommandStream.test.ts
@@ -1,0 +1,512 @@
+import { describe, expect, it, vi } from "vitest";
+import { type VertexBuffer } from "core/Buffers/buffer";
+import { type DataBuffer } from "core/Buffers/dataBuffer";
+import { type Nullable } from "core/types";
+import {
+    ApplyWebGPURenderPassDrawCommand,
+    type IWebGPURenderPassCommandRecorderProvider,
+    type IWebGPURenderPassIndexedDrawCommand,
+    type IWebGPURenderPassNonIndexedDrawCommand,
+    WebGPURenderPassCommandOpcode,
+    WebGPURenderPassCommandStream,
+    WebGPURenderPassCommandStreamProtocolVersion,
+    WebGPURenderPassDrawKind,
+} from "core/Engines/WebGPU/webgpuRenderPassCommandStream";
+import * as WebGPUConstants from "core/Engines/WebGPU/webgpuConstants";
+import { Logger } from "core/Misc/logger";
+
+const BackendResourceIdName = "__babylonNativeWebGPUHandleId";
+const U64Max = 0xffffffff;
+
+type RenderPassCall = [string, ...number[]];
+
+interface IRecordedCommandStream {
+    words: number[];
+    drawCount: number;
+    multiDrawCallCount: number;
+    multiDrawDrawCount: number;
+    wordCount: number;
+}
+
+function getBackendResourceId(resource: Nullable<object>): number {
+    const id = (resource as Record<string, unknown> | null)?.[BackendResourceIdName];
+    return typeof id === "number" && id > 0 ? id : 0;
+}
+
+function setBackendResourceId<T extends object>(resource: T, id: number): T {
+    (resource as Record<string, unknown>)[BackendResourceIdName] = id;
+    return resource;
+}
+
+function createResource<T extends object>(id: number): T {
+    return setBackendResourceId({} as T, id);
+}
+
+function createDataBuffer(id: number, is32Bits = true): DataBuffer {
+    return {
+        underlyingResource: createResource<GPUBuffer>(id),
+        is32Bits,
+    } as unknown as DataBuffer;
+}
+
+function createVertexBuffer(id: number, byteOffset = 0, validOffsetRange = true): VertexBuffer {
+    return {
+        effectiveBuffer: {
+            underlyingResource: createResource<GPUBuffer>(id),
+        },
+        byteOffset,
+        _validOffsetRange: validOffsetRange,
+    } as unknown as VertexBuffer;
+}
+
+function createReplayRenderPass(): { renderPass: GPURenderPassEncoder; calls: RenderPassCall[] } {
+    const calls: RenderPassCall[] = [];
+    const renderPass = {
+        setPipeline: (pipeline: GPURenderPipeline) => calls.push(["setPipeline", getBackendResourceId(pipeline)]),
+        setIndexBuffer: (buffer: GPUBuffer, format: string, offset?: number) =>
+            calls.push(["setIndexBuffer", getBackendResourceId(buffer), format === WebGPUConstants.IndexFormat.Uint32 ? 1 : 0, offset ?? 0]),
+        setVertexBuffer: (slot: number, buffer: GPUBuffer, offset?: number) => calls.push(["setVertexBuffer", slot, getBackendResourceId(buffer), offset ?? 0]),
+        setBindGroup: (slot: number, bindGroup: GPUBindGroup) => calls.push(["setBindGroup", slot, getBackendResourceId(bindGroup)]),
+        drawIndexed: (indexCount: number, instanceCount?: number, firstIndex?: number, baseVertex?: number, firstInstance?: number) =>
+            calls.push(["drawIndexed", indexCount, instanceCount ?? 1, firstIndex ?? 0, baseVertex ?? 0, firstInstance ?? 0]),
+        draw: (vertexCount: number, instanceCount?: number, firstVertex?: number, firstInstance?: number) =>
+            calls.push(["draw", vertexCount, instanceCount ?? 1, firstVertex ?? 0, firstInstance ?? 0]),
+        drawIndexedIndirect: (buffer: GPUBuffer, offset: number) => calls.push(["drawIndexedIndirect", getBackendResourceId(buffer), offset]),
+        drawIndirect: (buffer: GPUBuffer, offset: number) => calls.push(["drawIndirect", getBackendResourceId(buffer), offset]),
+    } as unknown as GPURenderPassEncoder;
+
+    return { renderPass, calls };
+}
+
+function createRecordingRenderPass(recordResult = true): { renderPass: GPURenderPassEncoder; records: IRecordedCommandStream[]; calls: RenderPassCall[] } {
+    const { renderPass, calls } = createReplayRenderPass();
+    const records: IRecordedCommandStream[] = [];
+
+    (renderPass as GPURenderPassEncoder & { _recordCommands: NonNullable<unknown> })._recordCommands = vi.fn(
+        (commands: Uint32Array, drawCount: number, multiDrawCallCount: number, multiDrawDrawCount: number, wordCount: number) => {
+            records.push({
+                words: Array.from(commands.subarray(0, wordCount)),
+                drawCount,
+                multiDrawCallCount,
+                multiDrawDrawCount,
+                wordCount,
+            });
+            return recordResult;
+        }
+    );
+
+    return { renderPass, records, calls };
+}
+
+function createProvider(enabled = true, lastError?: string): IWebGPURenderPassCommandRecorderProvider {
+    return {
+        protocolVersion: WebGPURenderPassCommandStreamProtocolVersion,
+        isEnabled: () => enabled,
+        getResourceId: getBackendResourceId,
+        getLastError: () => lastError,
+    };
+}
+
+function createStream(enabled = true, lastError?: string): WebGPURenderPassCommandStream {
+    const provider = createProvider(enabled, lastError);
+    return new WebGPURenderPassCommandStream({ getProvider: () => provider });
+}
+
+function createCommand(overrides: Partial<IWebGPURenderPassIndexedDrawCommand> = {}): IWebGPURenderPassIndexedDrawCommand {
+    const renderPass = overrides.renderPass ?? createRecordingRenderPass().renderPass;
+    return {
+        renderPass,
+        drawKind: WebGPURenderPassDrawKind.INDEXED,
+        pipeline: createResource<GPURenderPipeline>(100),
+        bindGroups: [createResource<GPUBindGroup>(201), createResource<GPUBindGroup>(202)],
+        vertexBuffers: [createVertexBuffer(301), createVertexBuffer(302, 8, false)],
+        indexBuffer: createDataBuffer(401),
+        indexFormat: WebGPUConstants.IndexFormat.Uint32,
+        count: 36,
+        instancesCount: 2,
+        start: 5,
+        indirectDrawBuffer: null,
+        ...overrides,
+    };
+}
+
+function createNonIndexedCommand(overrides: Partial<IWebGPURenderPassNonIndexedDrawCommand> = {}): IWebGPURenderPassNonIndexedDrawCommand {
+    const renderPass = overrides.renderPass ?? createRecordingRenderPass().renderPass;
+    return {
+        renderPass,
+        drawKind: WebGPURenderPassDrawKind.NON_INDEXED,
+        pipeline: createResource<GPURenderPipeline>(100),
+        bindGroups: [createResource<GPUBindGroup>(201), createResource<GPUBindGroup>(202)],
+        vertexBuffers: [createVertexBuffer(301), createVertexBuffer(302, 8, false)],
+        indexBuffer: null,
+        indexFormat: null,
+        count: 12,
+        instancesCount: 1,
+        start: 4,
+        indirectDrawBuffer: null,
+        ...overrides,
+    };
+}
+
+function parseOpcodes(words: number[]): number[] {
+    const opcodes: number[] = [];
+    for (let index = 0; index < words.length; ) {
+        const opcode = words[index];
+        opcodes.push(opcode);
+
+        switch (opcode) {
+            case WebGPURenderPassCommandOpcode.setPipeline:
+                index += 3;
+                break;
+            case WebGPURenderPassCommandOpcode.setBindGroup:
+            case WebGPURenderPassCommandOpcode.draw:
+            case WebGPURenderPassCommandOpcode.drawIndirect:
+            case WebGPURenderPassCommandOpcode.drawIndexedIndirect:
+                index += 5;
+                break;
+            case WebGPURenderPassCommandOpcode.setVertexBuffer:
+            case WebGPURenderPassCommandOpcode.setIndexBuffer:
+                index += 8;
+                break;
+            case WebGPURenderPassCommandOpcode.drawIndexed:
+                index += 6;
+                break;
+            default:
+                throw new Error(`Unexpected opcode ${opcode} at word ${index}`);
+        }
+    }
+    return opcodes;
+}
+
+describe("WebGPURenderPassCommandStream", () => {
+    it("does not record anything for an empty stream", () => {
+        const stream = createStream();
+
+        expect(stream.flush()).toBe(false);
+    });
+
+    it("records one indexed draw with the required state commands", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass }))).toBe(true);
+        expect(stream.flush()).toBe(true);
+
+        expect(records).toHaveLength(1);
+        expect(records[0].drawCount).toBe(1);
+        expect(records[0].multiDrawCallCount).toBe(0);
+        expect(records[0].multiDrawDrawCount).toBe(0);
+        expect(records[0].words).toEqual([
+            WebGPURenderPassCommandOpcode.setPipeline,
+            100,
+            0,
+            WebGPURenderPassCommandOpcode.setIndexBuffer,
+            401,
+            0,
+            1,
+            0,
+            0,
+            U64Max,
+            U64Max,
+            WebGPURenderPassCommandOpcode.setVertexBuffer,
+            0,
+            301,
+            0,
+            0,
+            0,
+            U64Max,
+            U64Max,
+            WebGPURenderPassCommandOpcode.setVertexBuffer,
+            1,
+            302,
+            0,
+            8,
+            0,
+            U64Max,
+            U64Max,
+            WebGPURenderPassCommandOpcode.setBindGroup,
+            0,
+            201,
+            0,
+            0,
+            WebGPURenderPassCommandOpcode.setBindGroup,
+            1,
+            202,
+            0,
+            0,
+            WebGPURenderPassCommandOpcode.drawIndexed,
+            36,
+            2,
+            5,
+            0,
+            0,
+        ]);
+    });
+
+    it("records many compatible draws without repeating stable state", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass, start: 0 }))).toBe(true);
+        expect(stream.tryAppend(createCommand({ renderPass, start: 36 }))).toBe(true);
+        expect(stream.tryAppend(createCommand({ renderPass, start: 72 }))).toBe(true);
+        stream.flush();
+
+        const opcodes = parseOpcodes(records[0].words);
+        expect(records[0].drawCount).toBe(3);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.setPipeline)).toHaveLength(1);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.setIndexBuffer)).toHaveLength(1);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.setVertexBuffer)).toHaveLength(2);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.setBindGroup)).toHaveLength(2);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.drawIndexed)).toHaveLength(3);
+    });
+
+    it("does not lower when the backend capability is absent", () => {
+        const { renderPass, calls } = createReplayRenderPass();
+        const stream = createStream(false);
+        const command = createCommand({ renderPass });
+
+        expect(stream.tryAppend(command)).toBe(false);
+        expect(stream.flush()).toBe(false);
+
+        ApplyWebGPURenderPassDrawCommand(command);
+        expect(calls.map((call) => call[0])).toEqual(["setPipeline", "setIndexBuffer", "setVertexBuffer", "setVertexBuffer", "setBindGroup", "setBindGroup", "drawIndexed"]);
+    });
+
+    it("does not lower when the backend capability is disabled even if backend recording exists", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream(false);
+
+        expect(stream.tryAppend(createCommand({ renderPass }))).toBe(false);
+        expect(stream.flush()).toBe(false);
+
+        expect(records).toHaveLength(0);
+    });
+
+    it("does not lower when the render pass has no backend recorder", () => {
+        const { renderPass, calls } = createReplayRenderPass();
+        const stream = createStream();
+        const command = createCommand({ renderPass });
+
+        expect(stream.tryAppend(command)).toBe(false);
+        ApplyWebGPURenderPassDrawCommand(command);
+
+        expect(calls[calls.length - 1]).toEqual(["drawIndexed", 36, 2, 5, 0, 0]);
+    });
+
+    it("does not permanently reject a resource after the backend resource id appears later", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const pipeline = {};
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass, pipeline: pipeline as GPURenderPipeline }))).toBe(false);
+
+        setBackendResourceId(pipeline, 100);
+        expect(stream.tryAppend(createCommand({ renderPass, pipeline: pipeline as GPURenderPipeline }))).toBe(true);
+        stream.flush();
+
+        expect(records).toHaveLength(1);
+        expect(records[0].drawCount).toBe(1);
+    });
+
+    it("does not lower a draw while any required backend resource id is missing", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass, bindGroups: [createResource<GPUBindGroup>(201), {} as GPUBindGroup] }))).toBe(false);
+        expect(stream.tryAppend(createCommand({ renderPass, vertexBuffers: [createVertexBuffer(301), { effectiveBuffer: { underlyingResource: {} } } as VertexBuffer] }))).toBe(
+            false
+        );
+        expect(stream.tryAppend(createCommand({ renderPass, indirectDrawBuffer: {} as GPUBuffer }))).toBe(false);
+        expect(stream.flush()).toBe(false);
+
+        expect(records).toHaveLength(0);
+    });
+
+    it("flushes an existing stream before appending to another render pass", () => {
+        const first = createRecordingRenderPass();
+        const second = createRecordingRenderPass();
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass: first.renderPass }))).toBe(true);
+        expect(stream.tryAppend(createCommand({ renderPass: second.renderPass }))).toBe(true);
+
+        expect(first.records).toHaveLength(1);
+        expect(second.records).toHaveLength(0);
+
+        stream.flush();
+        expect(second.records).toHaveLength(1);
+    });
+
+    it("re-emits required state after a completed stream is flushed", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass }))).toBe(true);
+        expect(stream.flush()).toBe(true);
+        expect(stream.tryAppend(createCommand({ renderPass }))).toBe(true);
+        expect(stream.flush()).toBe(true);
+
+        expect(records).toHaveLength(2);
+        for (const record of records) {
+            const opcodes = parseOpcodes(record.words);
+            expect(opcodes).toContain(WebGPURenderPassCommandOpcode.setPipeline);
+            expect(opcodes).toContain(WebGPURenderPassCommandOpcode.setIndexBuffer);
+            expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.setBindGroup)).toHaveLength(2);
+            expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.drawIndexed)).toHaveLength(1);
+        }
+    });
+
+    it("emits a new pipeline command when material-equivalent state changes", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass, pipeline: createResource<GPURenderPipeline>(100) }))).toBe(true);
+        expect(stream.tryAppend(createCommand({ renderPass, pipeline: createResource<GPURenderPipeline>(101) }))).toBe(true);
+        stream.flush();
+
+        const opcodes = parseOpcodes(records[0].words);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.setPipeline)).toHaveLength(2);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.drawIndexed)).toHaveLength(2);
+    });
+
+    it("emits only the changed bind-group slot for adjacent compatible draws", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass, bindGroups: [createResource<GPUBindGroup>(201), createResource<GPUBindGroup>(202)] }))).toBe(true);
+        expect(stream.tryAppend(createCommand({ renderPass, bindGroups: [createResource<GPUBindGroup>(201), createResource<GPUBindGroup>(203)] }))).toBe(true);
+        stream.flush();
+
+        const opcodes = parseOpcodes(records[0].words);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.setBindGroup)).toHaveLength(3);
+    });
+
+    it("emits a new index-buffer command when the index format changes", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+        const indexBuffer = createDataBuffer(401);
+
+        expect(stream.tryAppend(createCommand({ renderPass, indexBuffer, indexFormat: WebGPUConstants.IndexFormat.Uint32 }))).toBe(true);
+        expect(stream.tryAppend(createCommand({ renderPass, indexBuffer, indexFormat: WebGPUConstants.IndexFormat.Uint16 }))).toBe(true);
+        stream.flush();
+
+        const opcodes = parseOpcodes(records[0].words);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.setIndexBuffer)).toHaveLength(2);
+    });
+
+    it("emits a new vertex-buffer command when the vertex offset changes", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass, vertexBuffers: [createVertexBuffer(301), createVertexBuffer(302, 8, false)] }))).toBe(true);
+        expect(stream.tryAppend(createCommand({ renderPass, vertexBuffers: [createVertexBuffer(301), createVertexBuffer(302, 12, false)] }))).toBe(true);
+        stream.flush();
+
+        const opcodes = parseOpcodes(records[0].words);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.setVertexBuffer)).toHaveLength(3);
+    });
+
+    it("keeps indexed and non-indexed draws as distinct commands", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass }))).toBe(true);
+        expect(stream.tryAppend(createNonIndexedCommand({ renderPass, count: 12, instancesCount: 1, start: 4 }))).toBe(true);
+        stream.flush();
+
+        const opcodes = parseOpcodes(records[0].words);
+        expect(opcodes).toContain(WebGPURenderPassCommandOpcode.drawIndexed);
+        expect(opcodes).toContain(WebGPURenderPassCommandOpcode.draw);
+    });
+
+    it("records indirect draw commands without claiming multi-draw count-buffer lowering", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+
+        expect(stream.tryAppend(createCommand({ renderPass, indirectDrawBuffer: createResource<GPUBuffer>(501) }))).toBe(true);
+        expect(
+            stream.tryAppend(
+                createNonIndexedCommand({
+                    renderPass,
+                    indirectDrawBuffer: createResource<GPUBuffer>(502),
+                })
+            )
+        ).toBe(true);
+        stream.flush();
+
+        const opcodes = parseOpcodes(records[0].words);
+        expect(records[0].drawCount).toBe(2);
+        expect(records[0].multiDrawCallCount).toBe(0);
+        expect(records[0].multiDrawDrawCount).toBe(0);
+        expect(opcodes).toContain(WebGPURenderPassCommandOpcode.drawIndexedIndirect);
+        expect(opcodes).toContain(WebGPURenderPassCommandOpcode.drawIndirect);
+    });
+
+    it("grows command storage for long compatible runs without corrupting opcodes", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = createStream();
+
+        for (let drawIndex = 0; drawIndex < 80; drawIndex++) {
+            expect(stream.tryAppend(createCommand({ renderPass, start: drawIndex * 3 }))).toBe(true);
+        }
+        stream.flush();
+
+        const opcodes = parseOpcodes(records[0].words);
+        expect(records[0].drawCount).toBe(80);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.setPipeline)).toHaveLength(1);
+        expect(opcodes.filter((opcode) => opcode === WebGPURenderPassCommandOpcode.drawIndexed)).toHaveLength(80);
+    });
+
+    it("logs and permanently falls back when the host decoder protocol version does not match", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const provider = createProvider();
+        provider.protocolVersion = WebGPURenderPassCommandStreamProtocolVersion + 1;
+        const stream = new WebGPURenderPassCommandStream({ getProvider: () => provider });
+        const errorSpy = vi.spyOn(Logger, "Error").mockImplementation(() => {});
+
+        try {
+            expect(stream.tryAppend(createCommand({ renderPass }))).toBe(false);
+            expect(stream.tryAppend(createCommand({ renderPass }))).toBe(false);
+
+            expect(records).toHaveLength(0);
+            expect(errorSpy).toHaveBeenCalledTimes(1);
+            expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("protocol mismatch"));
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+
+    it("does not lower when no provider is installed", () => {
+        const { renderPass, records } = createRecordingRenderPass();
+        const stream = new WebGPURenderPassCommandStream({ getProvider: () => null });
+
+        expect(stream.tryAppend(createCommand({ renderPass }))).toBe(false);
+        expect(stream.flush()).toBe(false);
+
+        expect(records).toHaveLength(0);
+    });
+
+    it("logs backend diagnostics and permanently falls back when backend recording fails", () => {
+        const { renderPass, records } = createRecordingRenderPass(false);
+        const stream = createStream(true, "validation failed");
+        const errorSpy = vi.spyOn(Logger, "Error").mockImplementation(() => {});
+
+        try {
+            expect(stream.tryAppend(createCommand({ renderPass }))).toBe(true);
+            expect(stream.flush()).toBe(false);
+
+            expect(errorSpy).toHaveBeenCalledTimes(1);
+            expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("validation failed"));
+
+            // After a backend failure the stream must stop lowering so draws replay through direct
+            // encoder calls instead of failing (and logging) on every subsequent flush.
+            expect(stream.tryAppend(createCommand({ renderPass }))).toBe(false);
+            expect(stream.flush()).toBe(false);
+            expect(records).toHaveLength(1);
+            expect(errorSpy).toHaveBeenCalledTimes(1);
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+});

--- a/packages/dev/core/test/unit/Engines/WebGPU/webgpuRenderPassCommandStream.test.ts
+++ b/packages/dev/core/test/unit/Engines/WebGPU/webgpuRenderPassCommandStream.test.ts
@@ -323,6 +323,20 @@ describe("WebGPURenderPassCommandStream", () => {
         expect(records).toHaveLength(0);
     });
 
+    it("does not lower a draw whose resource id exceeds the safe-integer range", () => {
+        const { renderPass, records, calls } = createRecordingRenderPass();
+        const stream = createStream();
+        const command = createCommand({ renderPass, pipeline: createResource<GPURenderPipeline>(2 ** 53) });
+
+        expect(stream.tryAppend(command)).toBe(false);
+        expect(stream.flush()).toBe(false);
+        expect(records).toHaveLength(0);
+
+        // The draw still renders through direct encoder replay.
+        ApplyWebGPURenderPassDrawCommand(command);
+        expect(calls.map((call) => call[0])).toContain("drawIndexed");
+    });
+
     it("flushes an existing stream before appending to another render pass", () => {
         const first = createRecordingRenderPass();
         const second = createRecordingRenderPass();

--- a/packages/dev/core/test/unit/Engines/WebGPU/webgpuRenderPassFlushBoundaries.test.ts
+++ b/packages/dev/core/test/unit/Engines/WebGPU/webgpuRenderPassFlushBoundaries.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Flush-boundary scenario tests for the WebGPU render pass command stream.
+ *
+ * These tests exercise the real engine prototype methods (occlusion queries, debug markers) against
+ * a semantic model of a native render pass: a GPU timeline that executes both direct encoder calls
+ * and decoded command-stream batches in submission order. The assertions are about user-visible
+ * outcomes — "which draws did this occlusion query observe", "which draws does this debug group
+ * contain" — not about the ordinality of encoder calls. In particular they pin the failure mode
+ * where a draw batched between beginOcclusionQuery/endOcclusionQuery would otherwise be recorded
+ * after the bracket closes, making the query report zero samples and the mesh wrongly disappear as
+ * "occluded".
+ */
+import { describe, expect, it, vi } from "vitest";
+import { type VertexBuffer } from "core/Buffers/buffer";
+import { type DataBuffer } from "core/Buffers/dataBuffer";
+import { type Nullable } from "core/types";
+import { RenderCommandBatcher } from "core/Engines/renderCommandBatcher.pure";
+import {
+    ApplyWebGPURenderPassDrawCommand,
+    type IWebGPURenderPassCommandRecorderProvider,
+    type IWebGPURenderPassDrawCommand,
+    WebGPURenderPassCommandOpcode,
+    WebGPURenderPassCommandStream,
+    WebGPURenderPassCommandStreamProtocolVersion,
+    WebGPURenderPassDrawKind,
+} from "core/Engines/WebGPU/webgpuRenderPassCommandStream";
+import * as WebGPUConstants from "core/Engines/WebGPU/webgpuConstants";
+import { ThinWebGPUEngine } from "core/Engines/thinWebGPUEngine";
+import { WebGPUEngine } from "core/Engines/webgpuEngine.pure";
+import { RegisterEnginesWebGPUExtensionsEngineQuery } from "core/Engines/WebGPU/Extensions/engine.query.pure";
+import { RegisterWebGPUDebugging } from "core/Engines/WebGPU/Extensions/engine.debugging.pure";
+import { type OcclusionQuery } from "core/Engines/AbstractEngine/abstractEngine.query.pure";
+
+// The code under test is the extension registration functions above: they attach the production
+// occlusion-query and debug-marker methods (including their flush-boundary handling) onto the engine
+// prototypes. The engine base classes themselves are not under test, and their real modules pull a
+// transitive import graph (shader modules) that cannot resolve in unit tests — so they are replaced
+// with bare classes for the registrations to attach to.
+vi.mock("core/Engines/thinWebGPUEngine", () => ({ ThinWebGPUEngine: class {} }));
+vi.mock("core/Engines/webgpuEngine.pure", () => ({ WebGPUEngine: class {} }));
+
+RegisterEnginesWebGPUExtensionsEngineQuery();
+RegisterWebGPUDebugging();
+
+const ResourceIds = new WeakMap<object, number>();
+let NextResourceId = 1;
+
+function createTrackedResource<T extends object>(): T {
+    const resource = {} as T;
+    ResourceIds.set(resource, NextResourceId++);
+    return resource;
+}
+
+const Provider: IWebGPURenderPassCommandRecorderProvider = {
+    protocolVersion: WebGPURenderPassCommandStreamProtocolVersion,
+    isEnabled: () => true,
+    getResourceId: (resource: Nullable<object>) => (resource ? (ResourceIds.get(resource) ?? 0) : 0),
+};
+
+interface ISemanticDraw {
+    start: number;
+    queryIndex: Nullable<number>;
+    groups: string[];
+    viaCommandStream: boolean;
+}
+
+/**
+ * Models what the native backend does with a render pass: executes direct encoder calls and decoded
+ * command-stream batches in the order they arrive, attributing every executed draw to the occlusion
+ * query and debug groups that are open at execution time.
+ */
+class SemanticRenderPass {
+    public readonly draws: ISemanticDraw[] = [];
+    private _activeQueryIndex: Nullable<number> = null;
+    private readonly _groupStack: string[] = [];
+
+    // Direct (unbatched) encoder surface.
+    public setPipeline(): void {}
+    public setIndexBuffer(): void {}
+    public setVertexBuffer(): void {}
+    public setBindGroup(): void {}
+    public drawIndexed(_indexCount: number, _instanceCount?: number, firstIndex?: number): void {
+        this._executeDraw(firstIndex ?? 0, false);
+    }
+    public draw(_vertexCount: number, _instanceCount?: number, firstVertex?: number): void {
+        this._executeDraw(firstVertex ?? 0, false);
+    }
+    public beginOcclusionQuery(queryIndex: number): void {
+        this._activeQueryIndex = queryIndex;
+    }
+    public endOcclusionQuery(): void {
+        this._activeQueryIndex = null;
+    }
+    public pushDebugGroup(groupName: string): void {
+        this._groupStack.push(groupName);
+    }
+    public popDebugGroup(): void {
+        this._groupStack.pop();
+    }
+    public insertDebugMarker(): void {}
+    public end(): void {}
+
+    // Host recording hook: decodes a batched command stream the way the native backend would.
+    public _recordCommands = (words: Uint32Array, _drawCount: number, _multiDrawCallCount: number, _multiDrawDrawCount: number, wordCount: number): boolean => {
+        let index = 0;
+        while (index < wordCount) {
+            const opcode = words[index];
+            switch (opcode) {
+                case WebGPURenderPassCommandOpcode.setPipeline:
+                    index += 3;
+                    break;
+                case WebGPURenderPassCommandOpcode.setBindGroup:
+                    index += 5;
+                    break;
+                case WebGPURenderPassCommandOpcode.setVertexBuffer:
+                case WebGPURenderPassCommandOpcode.setIndexBuffer:
+                    index += 8;
+                    break;
+                case WebGPURenderPassCommandOpcode.draw:
+                    this._executeDraw(words[index + 3], true);
+                    index += 5;
+                    break;
+                case WebGPURenderPassCommandOpcode.drawIndexed:
+                    this._executeDraw(words[index + 3], true);
+                    index += 6;
+                    break;
+                case WebGPURenderPassCommandOpcode.drawIndirect:
+                case WebGPURenderPassCommandOpcode.drawIndexedIndirect:
+                    this._executeDraw(-1, true);
+                    index += 5;
+                    break;
+                default:
+                    throw new Error(`Unexpected opcode ${opcode} at word ${index}`);
+            }
+        }
+        return true;
+    };
+
+    // Number of draws the query observed — the stand-in for the samples-passed result a mesh's
+    // occlusion state is derived from.
+    public samplesPassedForQuery(queryIndex: number): number {
+        return this.draws.filter((draw) => draw.queryIndex === queryIndex).length;
+    }
+
+    public drawStartsForQuery(queryIndex: number): number[] {
+        return this.draws.filter((draw) => draw.queryIndex === queryIndex).map((draw) => draw.start);
+    }
+
+    public drawStartsOutsideQueries(): number[] {
+        return this.draws.filter((draw) => draw.queryIndex === null).map((draw) => draw.start);
+    }
+
+    public drawStartsInGroup(groupName: string): number[] {
+        return this.draws.filter((draw) => draw.groups.includes(groupName)).map((draw) => draw.start);
+    }
+
+    private _executeDraw(start: number, viaCommandStream: boolean): void {
+        this.draws.push({ start, queryIndex: this._activeQueryIndex, groups: [...this._groupStack], viaCommandStream });
+    }
+}
+
+function createBatcher(): RenderCommandBatcher<IWebGPURenderPassDrawCommand> {
+    const stream = new WebGPURenderPassCommandStream({ getProvider: () => Provider });
+    return new RenderCommandBatcher<IWebGPURenderPassDrawCommand>(stream, ApplyWebGPURenderPassDrawCommand);
+}
+
+function submitDraw(batcher: RenderCommandBatcher<IWebGPURenderPassDrawCommand>, renderPass: SemanticRenderPass, start: number): void {
+    const lowered = batcher.submit({
+        renderPass: renderPass as unknown as GPURenderPassEncoder,
+        drawKind: WebGPURenderPassDrawKind.INDEXED,
+        pipeline: createTrackedResource<GPURenderPipeline>(),
+        bindGroups: [createTrackedResource<GPUBindGroup>()],
+        vertexBuffers: [
+            {
+                effectiveBuffer: { underlyingResource: createTrackedResource<GPUBuffer>() },
+                byteOffset: 0,
+                _validOffsetRange: true,
+            } as unknown as VertexBuffer,
+        ],
+        indexBuffer: { underlyingResource: createTrackedResource<GPUBuffer>(), is32Bits: true } as unknown as DataBuffer,
+        indexFormat: WebGPUConstants.IndexFormat.Uint32,
+        count: 36,
+        instancesCount: 1,
+        start,
+        indirectDrawBuffer: null,
+    });
+
+    // The scenarios below are only meaningful if the draw actually takes the batched path.
+    expect(lowered).toBe(true);
+}
+
+// Builds the minimal engine state the registered ThinWebGPUEngine occlusion-query methods rely on,
+// with the flush hook wired to the batcher exactly like WebGPUEngine._flushRenderPassCommands.
+function createOcclusionQueryEngine(renderPass: SemanticRenderPass, batcher: RenderCommandBatcher<IWebGPURenderPassDrawCommand>): ThinWebGPUEngine {
+    const engine = {
+        compatibilityMode: true,
+        _occlusionQuery: { canBeginQuery: () => true },
+        _currentRenderPass: renderPass,
+        _flushRenderPassCommands: () => void batcher.flush(),
+    };
+    Object.setPrototypeOf(engine, ThinWebGPUEngine.prototype);
+    return engine as unknown as ThinWebGPUEngine;
+}
+
+// Builds the minimal engine state the registered WebGPUEngine debug-marker methods rely on, with
+// the flush hook wired to the batcher exactly like WebGPUEngine._flushRenderPassCommands.
+function createDebugMarkersEngine(renderPass: SemanticRenderPass, batcher: RenderCommandBatcher<IWebGPURenderPassDrawCommand>): WebGPUEngine {
+    const engine = {
+        _enableGPUDebugMarkers: true,
+        _showGPUDebugMarkersLog: false,
+        frameId: 1,
+        _currentRenderPass: renderPass,
+        _renderEncoder: {},
+        _debugMarkersPassGroups: [],
+        _debugMarkersEncoderGroups: [],
+        _debugMarkersPendingEncoderPops: 0,
+        _flushRenderPassCommands: () => void batcher.flush(),
+    };
+    Object.setPrototypeOf(engine, WebGPUEngine.prototype);
+    return engine as unknown as WebGPUEngine;
+}
+
+describe("WebGPU render pass command stream flush boundaries", () => {
+    describe("occlusion queries", () => {
+        it("keeps a batched draw inside the occlusion query that brackets it, so a visible mesh is not misreported as occluded", () => {
+            const renderPass = new SemanticRenderPass();
+            const batcher = createBatcher();
+            const engine = createOcclusionQueryEngine(renderPass, batcher);
+            const queryIndex = 7;
+
+            submitDraw(batcher, renderPass, 0); // unrelated draw issued before the query opens
+            expect(engine.beginOcclusionQuery(0, queryIndex as unknown as OcclusionQuery)).toBe(true);
+            submitDraw(batcher, renderPass, 36); // the mesh whose visibility the query measures
+            engine.endOcclusionQuery(0);
+            submitDraw(batcher, renderPass, 72); // unrelated draw issued after the query closes
+            batcher.flush(); // render pass ends
+
+            // Zero samples here is the user-visible bug this boundary flushing prevents: the mesh
+            // would be flagged occluded and disappear even though it was drawn.
+            expect(renderPass.samplesPassedForQuery(queryIndex)).toBeGreaterThan(0);
+            expect(renderPass.drawStartsForQuery(queryIndex)).toEqual([36]);
+
+            // Draws issued outside the bracket must not inflate the query result either.
+            expect(renderPass.drawStartsOutsideQueries()).toEqual([0, 72]);
+
+            // The boundary flushes must keep the draws on the batched path rather than silently
+            // degrading them to one-call-per-draw replay.
+            expect(renderPass.draws.map((draw) => draw.viaCommandStream)).toEqual([true, true, true]);
+        });
+
+        it("reports zero samples for a query that brackets no draws, even with batched draws pending around it", () => {
+            const renderPass = new SemanticRenderPass();
+            const batcher = createBatcher();
+            const engine = createOcclusionQueryEngine(renderPass, batcher);
+            const queryIndex = 3;
+
+            submitDraw(batcher, renderPass, 0); // pending when the empty bracket opens
+            expect(engine.beginOcclusionQuery(0, queryIndex as unknown as OcclusionQuery)).toBe(true);
+            engine.endOcclusionQuery(0);
+            submitDraw(batcher, renderPass, 36); // issued after the bracket closed
+            batcher.flush();
+
+            // Neither the draw pending before the bracket nor the one issued after it may leak in:
+            // a leak would report a fully occluded mesh as visible.
+            expect(renderPass.samplesPassedForQuery(queryIndex)).toBe(0);
+            expect(renderPass.drawStartsOutsideQueries()).toEqual([0, 36]);
+        });
+
+        it("attributes draws to the correct query across consecutive brackets in one batch run", () => {
+            const renderPass = new SemanticRenderPass();
+            const batcher = createBatcher();
+            const engine = createOcclusionQueryEngine(renderPass, batcher);
+
+            expect(engine.beginOcclusionQuery(0, 1 as unknown as OcclusionQuery)).toBe(true);
+            submitDraw(batcher, renderPass, 10);
+            engine.endOcclusionQuery(0);
+            expect(engine.beginOcclusionQuery(0, 2 as unknown as OcclusionQuery)).toBe(true);
+            submitDraw(batcher, renderPass, 20);
+            engine.endOcclusionQuery(0);
+            batcher.flush();
+
+            expect(renderPass.drawStartsForQuery(1)).toEqual([10]);
+            expect(renderPass.drawStartsForQuery(2)).toEqual([20]);
+        });
+    });
+
+    describe("debug marker groups", () => {
+        it("attributes batched draws to the debug group that was open when they were issued", () => {
+            const renderPass = new SemanticRenderPass();
+            const batcher = createBatcher();
+            const engine = createDebugMarkersEngine(renderPass, batcher);
+
+            submitDraw(batcher, renderPass, 0); // issued before the group opens
+            engine._debugPushGroup("portal interior");
+            submitDraw(batcher, renderPass, 36); // issued inside the group
+            engine._debugPopGroup();
+            submitDraw(batcher, renderPass, 72); // issued after the group closes
+            batcher.flush();
+
+            // A GPU capture must show exactly the draw issued inside the group — otherwise frame
+            // debugging attributes work to the wrong scope.
+            expect(renderPass.drawStartsInGroup("portal interior")).toEqual([36]);
+            expect(renderPass.draws.map((draw) => draw.viaCommandStream)).toEqual([true, true, true]);
+        });
+
+        it("keeps draws batched while nesting and unwinding debug groups", () => {
+            const renderPass = new SemanticRenderPass();
+            const batcher = createBatcher();
+            const engine = createDebugMarkersEngine(renderPass, batcher);
+
+            engine._debugPushGroup("frame");
+            submitDraw(batcher, renderPass, 0);
+            engine._debugPushGroup("shadows");
+            submitDraw(batcher, renderPass, 36);
+            engine._debugPopGroup();
+            submitDraw(batcher, renderPass, 72);
+            engine._debugPopGroup();
+            batcher.flush();
+
+            expect(renderPass.drawStartsInGroup("frame")).toEqual([0, 36, 72]);
+            expect(renderPass.drawStartsInGroup("shadows")).toEqual([36]);
+            expect(renderPass.draws.map((draw) => draw.viaCommandStream)).toEqual([true, true, true]);
+        });
+    });
+});

--- a/packages/dev/core/test/unit/Engines/renderCommandBatcher.test.ts
+++ b/packages/dev/core/test/unit/Engines/renderCommandBatcher.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { type IRenderCommandLowering, RenderCommandBatcher } from "core/Engines/renderCommandBatcher.pure";
+
+interface ITestCommand {
+    id: number;
+}
+
+function createLowering(appendResults: boolean[]): { lowering: IRenderCommandLowering<ITestCommand>; events: string[] } {
+    const events: string[] = [];
+    const lowering: IRenderCommandLowering<ITestCommand> = {
+        tryAppend: (command) => {
+            events.push(`try:${command.id}`);
+            return appendResults.shift() ?? false;
+        },
+        flush: () => {
+            events.push("flush");
+            return true;
+        },
+        reset: () => {
+            events.push("reset");
+        },
+    };
+
+    return { lowering, events };
+}
+
+describe("RenderCommandBatcher", () => {
+    it("replays when no lowering is installed", () => {
+        const replay = vi.fn();
+        const batcher = new RenderCommandBatcher<ITestCommand>(null, replay);
+
+        expect(batcher.submit({ id: 1 })).toBe(false);
+        expect(replay).toHaveBeenCalledExactlyOnceWith({ id: 1 });
+        expect(batcher.flush()).toBe(false);
+
+        expect(() => batcher.reset()).not.toThrow();
+    });
+
+    it("does not replay commands that lower successfully", () => {
+        const { lowering, events } = createLowering([true]);
+        const replay = vi.fn();
+        const batcher = new RenderCommandBatcher(lowering, replay);
+
+        expect(batcher.submit({ id: 1 })).toBe(true);
+
+        expect(replay).not.toHaveBeenCalled();
+        expect(events).toEqual(["try:1"]);
+    });
+
+    it("flushes lowered commands before replaying a command that cannot lower", () => {
+        const { lowering, events } = createLowering([true, false]);
+        const replay = vi.fn((command: ITestCommand) => events.push(`replay:${command.id}`));
+        const batcher = new RenderCommandBatcher(lowering, replay);
+
+        expect(batcher.submit({ id: 1 })).toBe(true);
+        expect(batcher.submit({ id: 2 })).toBe(false);
+
+        expect(events).toEqual(["try:1", "try:2", "flush", "replay:2"]);
+    });
+
+    it("handles zero, one, and many explicit flushes through the lowerer", () => {
+        const { lowering, events } = createLowering([true, true]);
+        const batcher = new RenderCommandBatcher(lowering, vi.fn());
+
+        expect(batcher.flush()).toBe(true);
+        expect(batcher.submit({ id: 1 })).toBe(true);
+        expect(batcher.flush()).toBe(true);
+        expect(batcher.submit({ id: 2 })).toBe(true);
+        expect(batcher.flush()).toBe(true);
+
+        expect(events).toEqual(["flush", "try:1", "flush", "try:2", "flush"]);
+    });
+
+    it("delegates reset only when a lowerer exists", () => {
+        const { lowering, events } = createLowering([]);
+        const batcher = new RenderCommandBatcher(lowering, vi.fn());
+
+        batcher.reset();
+
+        expect(events).toEqual(["reset"]);
+    });
+});


### PR DESCRIPTION
> Upstreamed as [BabylonJS/Babylon.js#18562](https://github.com/BabylonJS/Babylon.js/pull/18562).

## Summary

This PR adds an internal render-command batching layer for WebGPU draw submission, bringing the WebGPU engine into congruence with a pattern Babylon.js core already ships: the bgfx-based NativeEngine batches its engine commands through a `CommandBufferEncoder` (`thinNativeEngine.pure.ts`) and flushes them across the JS/native bridge in bulk, rather than paying one Node-API crossing per call. The WebGPU engine had no equivalent layer, so on hosts like BabylonNative with WebGPU backed by wgpu-native, every `setPipeline`, `setBindGroup`, `setVertexBuffer`, `setIndexBuffer`, and `draw*` crossed the JavaScriptCore/Node-API boundary individually — the CPU bottleneck profiled in [this forum post](https://forum.babylonjs.com/t/solving-cpu-bottleneck-in-nativexr-hill-valley-ar-portal-scene/63558).

This is also the same architecture browsers use one layer down for the identical boundary problem: Chromium's Dawn wire protocol serializes WebGPU commands into batched buffers across the renderer-to-GPU-process boundary, and Unreal's `FRHICommandList` records on the render thread and translates on the RHI thread. The boundary here is N-API rather than IPC or a thread hop; the remedy is the same.

**Scope note:** this is transport-level, order-preserving submission batching — not draw merging. It does not reorder, sort, or combine draws, so it composes with (rather than competes against) instancing, and the stream format reserves multi-draw fields for future multi-draw-indirect lowering (wgpu exposes MDI natively even though it is not yet in the WebGPU spec).

## Architecture

- `RenderCommandBatcher` — small generic lower-or-replay adapter: try the optional lowering path; for a draw that cannot lower, flush pending lowered work first, then replay the original command exactly once. Ordering is preserved unconditionally.
- `WebGPURenderPassCommandStream` — the WebGPU-specific lowerer: encodes draws as opcode words into a reused `Uint32Array`, state-diffing pipeline, index/vertex buffers, and bind groups so redundant state is elided before it is ever recorded, then submits the whole batch through a single `_recordCommands` call on the render pass.
- Flush boundaries: batched draws are recorded before every direct render-pass mutation — viewport, scissor, stencil reference, blend constant, full-quad clears, **occlusion query begin/end**, **debug marker push/pop/insert**, and render-pass end — through a `ThinWebGPUEngine._flushRenderPassCommands()` seam (a no-op for engines that do not batch). Without these boundaries, a draw batched inside an occlusion-query bracket would be recorded after the bracket closes (the query reports zero samples and the mesh wrongly disappears as occluded), and GPU captures would attribute draws to the wrong debug group.
- The draw hot path is allocation-free: the engine reuses two scratch draw-command objects (both the lowering and replay paths consume commands synchronously), and the stream reuses scratch id arrays. With no provider installed — always the case in browsers — the per-draw overhead is a null check and a work-free flush, and draws take the standard WebGPU encoder calls unchanged.
- Failure policy: a protocol-version mismatch or a backend recording failure logs one error (enriched with the provider's diagnostics) and permanently falls back to direct encoder calls for that engine — nothing throws from the render loop.
- Typed indexed/non-indexed draw command variants instead of a magic numeric draw type.

## Host contract

A host opts in by installing a provider on the engine:

```js
engine.renderPassCommandRecorderProvider = {
    protocolVersion: 1,                       // must equal WebGPURenderPassCommandStreamProtocolVersion in the decoder build
    isEnabled: () => true,                    // host-controlled toggle
    getResourceId: (resource) => /* host handle id for a pipeline/buffer/bind group, or 0 */,
    getLastError: () => /* optional backend diagnostics for failure logs */,
};
```

and exposing a `_recordCommands(words, drawCount, multiDrawCallCount, multiDrawDrawCount, wordCount)` hook on its render-pass encoders. The recorder must consume the words synchronously — the buffer is reused after the call returns. The `protocolVersion` handshake mirrors the `PROTOCOL_VERSION` guard the bgfx-based NativeEngine uses to keep the JS encoder and native decoder from drifting.

## Test coverage

- Contract-level unit coverage of the batcher and stream: lowering absent/present/disabled, fallback replay with flush-before-replay ordering, state-diff behavior per state kind, indexed/non-indexed/indirect draws, late resource ids, command storage growth, render-pass boundary flushing, no-provider behavior, protocol-version mismatch, and permanent fallback with diagnostics when backend recording fails.
- Flush-boundary scenario tests (`webgpuRenderPassFlushBoundaries.test.ts`) drive the real registered engine prototype methods against a semantic model of the native render pass: a GPU timeline that executes direct calls and decoded command-stream batches in submission order, attributing each executed draw to the occlusion query and debug groups open at execution time. Assertions are on user-visible outcomes — "which draws did query N observe", "which draws are inside group X", "did the draws stay on the batched path" — not on encoder-call ordinality.

## Validation

- `npx vitest run --project=unit` over `packages/dev/core/test/unit` — 2618 tests pass (111 files), including 30 focused tests across `renderCommandBatcher.test.ts`, `webgpuRenderPassCommandStream.test.ts`, and `webgpuRenderPassFlushBoundaries.test.ts`.
- `npx eslint --quiet` over all changed source and test files — passed.
- `npm --workspace @dev/core run build` — passed.
- `npm --workspace babylonjs run build:prod` — passed.

Native integration validation using BabylonNative Release/LTO macOS Playground with the non-AR Hill Valley stress scene:

- Scene rendered with material parity checks passing: `issues=0`; SSAO2 stayed enabled in `mode=prepass`.
- Command stream enabled, steady windows: roughly 13,920 draws / 2s grouped into roughly 720 command-stream bridge calls — about 94.8% fewer draw-level bridge traversals — at 59.5–60.5 native fps.
- Command stream disabled, steady windows: same draw volume, `cmdStreams=0`, roughly 59–60 native fps.

The M4 local stress path is vsync-bound, so that run is bridge-call-reduction proof rather than an FPS claim. The motivating device wins (iPhone XS roughly 40→45 fps with improved 1% lows; reduced peak CPU on iPhone 12/A14) are documented in the forum post linked above.

## Future work

- Multi-draw-indirect lowering through the reserved `multiDrawCallCount`/`multiDrawDrawCount` stream fields (wgpu-native exposes MDI; the WebGPU spec does not yet).
- Lower debug markers (`pushDebugGroup`/`popDebugGroup`/`insertDebugMarker`) into stream opcodes so that enabling GPU profiler markers does not fragment batches with boundary flushes — today markers stay correct (flushed) but each marker costs a bridge crossing and splits the batch, which is acceptable for profiling sessions only.
- The command-stream types already admit `GPURenderBundleEncoder`, so the same lowering could batch bundle construction under `compatibilityMode = false` if profiling justifies it.
- Comparison numbers against `compatibilityMode = false` and snapshot rendering on the same scenes.
