### PR TITLE
Move custom frame requester to AbstractEngine to enable 120fps support in BabylonNative

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.pure.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.pure.ts
@@ -1034,7 +1034,7 @@ export abstract class AbstractEngine {
     }
 
     /** @internal */
-    public _renderLoop(timestamp: number | undefined): void {
+    public _renderLoop(timestamp?: number): void {
         this._processFrame(timestamp);
 
         // The first condition prevents queuing another frame if we no longer have active render loops (e.g., if

--- a/packages/dev/core/src/Engines/abstractEngine.pure.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.pure.ts
@@ -902,6 +902,7 @@ export abstract class AbstractEngine {
                 if (cancelAnimationFrame) {
                     cancelAnimationFrame(this.customAnimationFrameRequester.requestID);
                 }
+                delete this.customAnimationFrameRequester.requestID;
             }
             return;
         }

--- a/packages/dev/core/src/Engines/abstractEngine.pure.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.pure.ts
@@ -38,6 +38,7 @@ import { type WebRequest } from "core/Misc/webRequest";
 import { type PerformanceMonitor } from "core/Misc/performanceMonitor";
 import { type ILoadingScreen } from "../Loading/loadingScreen.pure";
 import { EngineStore } from "./engineStore";
+import { type ICustomAnimationFrameRequester } from "../Misc/customAnimationFrameRequester";
 import { Logger } from "../Misc/logger";
 import { PerformanceConfigurator } from "./performanceConfigurator";
 import { PrecisionDate } from "../Misc/precisionDate";
@@ -76,6 +77,13 @@ export function QueueNewFrame(func: () => void, requester?: any): number {
     // Note that there is kind of a typing issue here, as `setTimeout` might return something else than a number (NodeJs returns a NodeJS.Timeout object).
     // Also if the global `requestAnimationFrame`'s returnType is number, `requester.requestPostAnimationFrame` and `requester.requestAnimationFrame` types
     // are `any`.
+
+    if (requester) {
+        const { requestAnimationFrame } = requester as { requestAnimationFrame: (callback: FrameRequestCallback) => number };
+        if (typeof requestAnimationFrame === "function") {
+            return requestAnimationFrame(func);
+        }
+    }
 
     if (!IsWindowObjectExist()) {
         if (typeof requestAnimationFrame === "function") {
@@ -853,6 +861,11 @@ export abstract class AbstractEngine {
     protected _activeRenderLoops = new Array<() => void>();
 
     /**
+     * If set, will be used to request the next animation frame for the render loop
+     */
+    public customAnimationFrameRequester: Nullable<ICustomAnimationFrameRequester> = null;
+
+    /**
      * Gets the list of current active render loop functions
      * @returns a read only array with the current render loop functions
      */
@@ -882,6 +895,17 @@ export abstract class AbstractEngine {
     }
 
     protected _cancelFrame() {
+        if (this.customAnimationFrameRequester) {
+            if (this._frameHandler !== 0) {
+                this._frameHandler = 0;
+                const { cancelAnimationFrame } = this.customAnimationFrameRequester;
+                if (cancelAnimationFrame) {
+                    cancelAnimationFrame(this.customAnimationFrameRequester.requestID);
+                }
+            }
+            return;
+        }
+
         if (this._frameHandler !== 0) {
             const handlerToCancel = this._frameHandler;
             this._frameHandler = 0;
@@ -1016,7 +1040,7 @@ export abstract class AbstractEngine {
         // `stopRenderLoop` is called mid frame). The second condition prevents queuing another frame if one has
         // already been queued (e.g., if `stopRenderLoop` and `runRenderLoop` is called mid frame).
         if (this._activeRenderLoops.length > 0 && this._frameHandler === 0) {
-            this._frameHandler = this._queueNewFrame(this._boundRenderFunction, this.getHostWindow());
+            this._queueNewFrameForRenderLoop();
         }
     }
 
@@ -1042,6 +1066,18 @@ export abstract class AbstractEngine {
         return QueueNewFrame(bindedRenderFunction, requester);
     }
 
+    protected _queueNewFrameForRenderLoop(): void {
+        if (this.customAnimationFrameRequester) {
+            this.customAnimationFrameRequester.requestID = this._queueNewFrame(
+                this.customAnimationFrameRequester.renderFunction || this._boundRenderFunction,
+                this.customAnimationFrameRequester
+            );
+            this._frameHandler = this.customAnimationFrameRequester.requestID;
+        } else {
+            this._frameHandler = this._queueNewFrame(this._boundRenderFunction, this.getHostWindow());
+        }
+    }
+
     /**
      * Register and execute a render loop. The engine can have more than one render function
      * @param renderFunction defines the function to continuously execute
@@ -1055,7 +1091,7 @@ export abstract class AbstractEngine {
 
         // On the first added function, start the render loop.
         if (this._activeRenderLoops.length === 1 && this._frameHandler === 0) {
-            this._frameHandler = this._queueNewFrame(this._boundRenderFunction, this.getHostWindow());
+            this._queueNewFrameForRenderLoop();
         }
     }
 

--- a/packages/dev/core/src/Engines/engine.pure.ts
+++ b/packages/dev/core/src/Engines/engine.pure.ts
@@ -7,7 +7,6 @@ import { type ILoadingScreen } from "../Loading/loadingScreen.pure";
 import { EngineStore } from "./engineStore";
 import { type WebGLPipelineContext } from "./WebGL/webGLPipelineContext";
 import { type IPipelineContext } from "./IPipelineContext";
-import { type ICustomAnimationFrameRequester } from "../Misc/customAnimationFrameRequester";
 import { type EngineOptions, ThinEngine } from "./thinEngine.pure";
 import { Constants } from "./constants";
 import { type IViewportLike, type IColor4Like } from "../Maths/math.like";
@@ -321,11 +320,6 @@ export class Engine extends ThinEngine {
 
     // Members
 
-    /**
-     * If set, will be used to request the next animation frame for the render loop
-     */
-    public customAnimationFrameRequester: Nullable<ICustomAnimationFrameRequester> = null;
-
     private _rescalePostProcess: Nullable<PostProcess>;
 
     protected override get _supportsHardwareTextureRescaling() {
@@ -592,39 +586,6 @@ export class Engine extends ThinEngine {
      */
     public override getFontOffset(font: string): { ascent: number; height: number; descent: number } {
         return GetFontOffset(font);
-    }
-
-    protected override _cancelFrame() {
-        if (this.customAnimationFrameRequester) {
-            if (this._frameHandler !== 0) {
-                this._frameHandler = 0;
-                const { cancelAnimationFrame } = this.customAnimationFrameRequester;
-                if (cancelAnimationFrame) {
-                    cancelAnimationFrame(this.customAnimationFrameRequester.requestID);
-                }
-            }
-        } else {
-            super._cancelFrame();
-        }
-    }
-
-    public override _renderLoop(timestamp?: number): void {
-        this._processFrame(timestamp);
-
-        // The first condition prevents queuing another frame if we no longer have active render loops (e.g., if
-        // `stopRenderLoop` is called mid frame). The second condition prevents queuing another frame if one has
-        // already been queued (e.g., if `stopRenderLoop` and `runRenderLoop` is called mid frame).
-        if (this._activeRenderLoops.length > 0 && this._frameHandler === 0) {
-            if (this.customAnimationFrameRequester) {
-                this.customAnimationFrameRequester.requestID = this._queueNewFrame(
-                    this.customAnimationFrameRequester.renderFunction || this._boundRenderFunction,
-                    this.customAnimationFrameRequester
-                );
-                this._frameHandler = this.customAnimationFrameRequester.requestID;
-            } else {
-                this._frameHandler = this._queueNewFrame(this._boundRenderFunction, this.getHostWindow());
-            }
-        }
     }
 
     /**

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -505,8 +505,8 @@ export class ThinNativeEngine extends ThinEngine {
      */
     protected override _queueNewFrame(bindedRenderFunction: any, requester?: any): number {
         // Use the provided requestAnimationFrame, unless the requester is the window. In that case, we will default to the Babylon Native version of requestAnimationFrame.
-        if (requester.requestAnimationFrame && requester !== window) {
-            requester.requestAnimationFrame(bindedRenderFunction);
+        if (requester?.requestAnimationFrame && requester !== this.getHostWindow()) {
+            return requester.requestAnimationFrame(bindedRenderFunction);
         } else {
             this._engine.requestAnimationFrame(bindedRenderFunction);
         }

--- a/packages/dev/core/test/unit/Engines/nullEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/nullEngine.test.ts
@@ -1,4 +1,7 @@
-import { NullEngine } from "core/Engines";
+import { NullEngine } from "core/Engines/nullEngine";
+import { describe, expect, it } from "vitest";
+
+type RenderFrameCallback = (timestamp: number) => void;
 
 describe("NullEngine", () => {
     describe("constructor", () => {
@@ -35,6 +38,61 @@ describe("NullEngine", () => {
             expect(nullEngine.isDeterministicLockStep()).toBe(true);
             expect(nullEngine.getTimeStep()).toBe(500); // 0.5 seconds in ms
             expect(nullEngine.getLockstepMaxSteps()).toBe(4);
+        });
+    });
+
+    describe("render loop", () => {
+        it("notifies frame observables when driven by a custom animation frame requester", () => {
+            const nullEngine = new NullEngine();
+            const requestedCallbacks: RenderFrameCallback[] = [];
+            const canceledRequestIds: Array<number | undefined> = [];
+            let nextRequestId = 41;
+            let beginFrameCount = 0;
+            let endFrameCount = 0;
+            let renderCount = 0;
+            const renderLoop = () => {
+                renderCount++;
+            };
+
+            nullEngine.customAnimationFrameRequester = {
+                requestAnimationFrame: (callback: RenderFrameCallback) => {
+                    requestedCallbacks.push(callback);
+                    return nextRequestId++;
+                },
+                cancelAnimationFrame: (requestId?: number) => {
+                    canceledRequestIds.push(requestId);
+                },
+            };
+            nullEngine.onBeginFrameObservable.add(() => {
+                beginFrameCount++;
+            });
+            nullEngine.onEndFrameObservable.add(() => {
+                endFrameCount++;
+            });
+
+            try {
+                nullEngine.runRenderLoop(renderLoop);
+
+                expect(requestedCallbacks).toHaveLength(1);
+                expect(nullEngine._frameHandler).toBe(41);
+                expect(nullEngine.customAnimationFrameRequester.requestID).toBe(41);
+
+                requestedCallbacks[0](1000);
+
+                expect(beginFrameCount).toBe(1);
+                expect(renderCount).toBe(1);
+                expect(endFrameCount).toBe(1);
+                expect(requestedCallbacks).toHaveLength(2);
+                expect(nullEngine._frameHandler).toBe(42);
+                expect(nullEngine.customAnimationFrameRequester.requestID).toBe(42);
+
+                nullEngine.stopRenderLoop(renderLoop);
+
+                expect(canceledRequestIds).toEqual([42]);
+                expect(nullEngine._frameHandler).toBe(0);
+            } finally {
+                nullEngine.dispose();
+            }
         });
     });
 });

--- a/packages/dev/core/test/unit/Engines/nullEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/nullEngine.test.ts
@@ -90,6 +90,7 @@ describe("NullEngine", () => {
 
                 expect(canceledRequestIds).toEqual([42]);
                 expect(nullEngine._frameHandler).toBe(0);
+                expect(nullEngine.customAnimationFrameRequester.requestID).toBeUndefined();
             } finally {
                 nullEngine.dispose();
             }

--- a/packages/dev/core/test/unit/Engines/thinEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinEngine.test.ts
@@ -1,5 +1,8 @@
-import { Engine, ThinEngine } from "core/Engines";
+import { Engine } from "core/Engines/engine";
+import { ThinEngine } from "core/Engines/thinEngine";
 import { beforeEach, describe, expect, it } from "vitest";
+
+type RenderFrameCallback = (timestamp: number) => void;
 
 describe("Engine", () => {
     describe("constructor", () => {
@@ -16,6 +19,51 @@ describe("Engine", () => {
 });
 
 describe("ThinEngine", () => {
+    describe("render loop", () => {
+        it("uses the custom animation frame requester from AbstractEngine", () => {
+            const thinEngine = new ThinEngine(null);
+            const requestedCallbacks: RenderFrameCallback[] = [];
+            const canceledRequestIds: Array<number | undefined> = [];
+            let nextRequestId = 7;
+            let renderCount = 0;
+            const renderLoop = () => {
+                renderCount++;
+            };
+
+            thinEngine.customAnimationFrameRequester = {
+                requestAnimationFrame: (callback: RenderFrameCallback) => {
+                    requestedCallbacks.push(callback);
+                    return nextRequestId++;
+                },
+                cancelAnimationFrame: (requestId?: number) => {
+                    canceledRequestIds.push(requestId);
+                },
+            };
+
+            try {
+                thinEngine.runRenderLoop(renderLoop);
+
+                expect(requestedCallbacks).toHaveLength(1);
+                expect(thinEngine._frameHandler).toBe(7);
+                expect(thinEngine.customAnimationFrameRequester.requestID).toBe(7);
+
+                requestedCallbacks[0](1000);
+
+                expect(renderCount).toBe(1);
+                expect(requestedCallbacks).toHaveLength(2);
+                expect(thinEngine._frameHandler).toBe(8);
+                expect(thinEngine.customAnimationFrameRequester.requestID).toBe(8);
+
+                thinEngine.stopRenderLoop(renderLoop);
+
+                expect(canceledRequestIds).toEqual([8]);
+                expect(thinEngine._frameHandler).toBe(0);
+            } finally {
+                thinEngine.dispose();
+            }
+        });
+    });
+
     describe("getTexImageParametersForCreateTexture", () => {
         let thinEngine: ThinEngine;
 

--- a/packages/dev/core/test/unit/Engines/thinEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinEngine.test.ts
@@ -58,6 +58,7 @@ describe("ThinEngine", () => {
 
                 expect(canceledRequestIds).toEqual([8]);
                 expect(thinEngine._frameHandler).toBe(0);
+                expect(thinEngine.customAnimationFrameRequester.requestID).toBeUndefined();
             } finally {
                 thinEngine.dispose();
             }

--- a/packages/dev/core/test/unit/Engines/thinNativeEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinNativeEngine.test.ts
@@ -1,0 +1,41 @@
+import { ThinNativeEngine } from "core/Engines/thinNativeEngine";
+import { describe, expect, it } from "vitest";
+
+type NativeFrameRequester = {
+    requestAnimationFrame: (callback: () => void) => number;
+};
+
+type TestThinNativeEngine = {
+    _engine: {
+        requestAnimationFrame: (callback: () => void) => void;
+    };
+    _queueNewFrame: (callback: () => void, requester?: NativeFrameRequester) => number;
+};
+
+describe("ThinNativeEngine", () => {
+    describe("render loop", () => {
+        it("returns the custom animation frame request id", () => {
+            const thinNativeEngine = Object.create(ThinNativeEngine.prototype) as TestThinNativeEngine;
+            let nativeRequestUsed = false;
+            let requestedCallback: (() => void) | undefined;
+            const renderFunction = () => {};
+
+            thinNativeEngine._engine = {
+                requestAnimationFrame: () => {
+                    nativeRequestUsed = true;
+                },
+            };
+
+            const requestId = thinNativeEngine._queueNewFrame(renderFunction, {
+                requestAnimationFrame: (callback: () => void) => {
+                    requestedCallback = callback;
+                    return 23;
+                },
+            });
+
+            expect(requestId).toBe(23);
+            expect(requestedCallback).toBe(renderFunction);
+            expect(nativeRequestUsed).toBe(false);
+        });
+    });
+});

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/transmissionHelper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/transmissionHelper.ts
@@ -102,6 +102,9 @@ export class TransmissionHelper {
     private _opaqueMeshesCache: AbstractMesh[] = [];
     private _transparentMeshesCache: AbstractMesh[] = [];
     private _materialObservers: { [id: string]: Nullable<Observer<AbstractMesh>> } = {};
+    private _newMeshObserver: Nullable<Observer<AbstractMesh>> = null;
+    private _removedMeshObserver: Nullable<Observer<AbstractMesh>> = null;
+    private _disposed = false;
 
     // Material implementations registered by loaders. Each entry maps a material class
     // to its adapter class so the helper can classify and interact with materials
@@ -295,6 +298,13 @@ export class TransmissionHelper {
         // we need to defer the processing because _addMesh may be called as part as an instance mesh creation, in which case some
         // internal properties are not setup yet, like _sourceMesh (needed when doing mesh.material below)
         Tools.SetImmediate(() => {
+            // Guard: skip if the helper was disposed before this deferred callback fires.
+            // Without this, a disposed helper with a null _opaqueRenderTarget would stamp
+            // null onto transmission materials, overriding any texture already assigned by
+            // an active frame graph or other external code.
+            if (this._disposed) {
+                return;
+            }
             if (mesh.material) {
                 const classification = this._classifyMeshMaterials(mesh);
                 if (classification === "transparent") {
@@ -331,9 +341,9 @@ export class TransmissionHelper {
     private _parseScene(): void {
         this._scene.meshes.forEach(this._addMesh.bind(this));
         // Listen for when a mesh is added to the scene and add it to our cache lists.
-        this._scene.onNewMeshAddedObservable.add(this._addMesh.bind(this));
+        this._newMeshObserver = this._scene.onNewMeshAddedObservable.add(this._addMesh.bind(this));
         // Listen for when a mesh is removed from to the scene and remove it from our cache lists.
-        this._scene.onMeshRemovedObservable.add(this._removeMesh.bind(this));
+        this._removedMeshObserver = this._scene.onMeshRemovedObservable.add(this._removeMesh.bind(this));
     }
 
     // When one of the meshes in the scene has its material changed, make sure that it's in the correct cache list.
@@ -453,6 +463,39 @@ export class TransmissionHelper {
      * Dispose all the elements created by the Helper.
      */
     public dispose(): void {
+        // Set the disposed flag first so any pending SetImmediate callbacks (from _addMesh)
+        // are no-ops. Without this guard a deferred _classifyMeshMaterials call would stamp
+        // a null _opaqueRenderTarget onto transmission materials after disposal.
+        this._disposed = true;
+
+        // Unregister scene-level observers so this helper stops reacting to mesh changes.
+        this._newMeshObserver?.remove();
+        this._removedMeshObserver?.remove();
+        this._newMeshObserver = null;
+        this._removedMeshObserver = null;
+
+        // Remove per-mesh material-change observers for all tracked meshes.
+        const allTracked = [...this._transparentMeshesCache, ...this._opaqueMeshesCache];
+        for (const mesh of allTracked) {
+            const observer = this._materialObservers[mesh.uniqueId];
+            if (observer) {
+                observer.remove();
+                delete this._materialObservers[mesh.uniqueId];
+            }
+        }
+
+        // Also remove any remaining observers that were registered before deferred
+        // classification added their meshes to the caches.
+        for (const mesh of this._scene.meshes) {
+            const observer = this._materialObservers[mesh.uniqueId];
+            if (observer) {
+                observer.remove();
+                delete this._materialObservers[mesh.uniqueId];
+            }
+        }
+
+        this._materialObservers = {};
+
         this._scene._transmissionHelper = undefined;
         if (this._opaqueRenderTarget) {
             this._opaqueRenderTarget.dispose();

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -10,6 +10,7 @@ import {
     type Camera,
     type CubeTexture,
     type Engine,
+    type FrameGraph,
     type HDRCubeTexture,
     type IblCdfGenerator,
     type IblShadowsRenderPipeline,
@@ -18,8 +19,8 @@ import {
     type ISceneLoaderProgressEvent,
     type LoadAssetContainerOptions,
     type Nullable,
-    type Observable,
     type Observer,
+    type Observable,
     type PickingInfo,
     type ShaderMaterial,
     type ShadowGenerator,
@@ -116,8 +117,7 @@ async function WhenNext<T>(observable: Observable<T>, abortSignal: AbortSignal):
     });
 }
 
-const environmentMode = ["none", "auto", "url"] as const;
-type EnvironmentMode = (typeof environmentMode)[number];
+type EnvironmentMode = "none" | "auto" | "url";
 
 type ActivateModelOptions = Partial<{ source: string | File | ArrayBufferView }>;
 
@@ -532,6 +532,20 @@ export class Viewer extends ViewerBase implements IDisposable, IViewer {
     private readonly _shadowState: ShadowState = {};
     private _iblShadowsAnimationObserver: Nullable<Observer<Scene>> = null;
 
+    private _objectListFilters: ReadonlyArray<(mesh: AbstractMesh) => boolean> = [];
+    private _objectListModelChangedObserver: Nullable<Observer<Nullable<string | File | ArrayBufferView>>> = null;
+
+    /**
+     * Called whenever the filtered object lists managed by an active frame graph are recomputed.
+     * Each entry in the array corresponds to the filter at the same index passed to
+     * {@link _setActiveFrameGraph}. Called once immediately when _setActiveFrameGraph is called,
+     * and again after every model change. Override in a subclass to wire ObjectList input blocks
+     * or perform other per-model setup without managing observer lifetimes manually.
+     * @param _objectLists The filtered lists of meshes corresponding to the filters passed to _setActiveFrameGraph.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    protected _onObjectListsUpdated(_objectLists: ReadonlyArray<ReadonlyArray<AbstractMesh>>): void {}
+
     public constructor(
         private readonly _engine: AbstractEngine,
         protected readonly _options?: Readonly<ViewerOptions>
@@ -659,7 +673,7 @@ export class Viewer extends ViewerBase implements IDisposable, IViewer {
         this._applyCameraAutoOrbitSpeed();
         this._applyCameraAutoOrbitDelay();
 
-        this._scene.onAfterRenderCameraObservable.add(() => {
+        this._scene.onAfterRenderObservable.add(() => {
             this.onAfterRenderObservable.notifyObservers();
         });
 
@@ -938,16 +952,19 @@ export class Viewer extends ViewerBase implements IDisposable, IViewer {
     }
 
     protected _updateSSAOPipeline() {
+        // Always abort any in-flight SSAO init first, regardless of frame graph state.
+        this._ssaoAbortController?.abort(new AbortError("SSAO pipeline is being updated."));
+        this._ssaoAbortController = null;
+
         observePromise(
             (async () => {
-                this._ssaoAbortController?.abort(new AbortError("SSAO is being changed before previous SSAO finished initializing."));
                 this._ssaoAbortController = new AbortController();
                 const abortSignal = this._ssaoAbortController.signal;
 
                 await this._updateSSAOLock.lockAsync(async () => {
-                    let shouldEnable = this._ssaoOption === "enabled";
+                    let shouldEnable = this._ssaoOption === "enabled" && !this._scene.frameGraph;
 
-                    if (this._ssaoOption === "auto") {
+                    if (this._ssaoOption === "auto" && !this._scene.frameGraph) {
                         const hasModels = this._loadedModels.length > 0;
                         const hasMaterials = this._loadedModels.some((model) => model.assetContainer.materials.length > 0);
                         const iblShadowsEnabled = this._shadowQuality === "high";
@@ -968,6 +985,47 @@ export class Viewer extends ViewerBase implements IDisposable, IViewer {
                 });
             })()
         );
+    }
+
+    /**
+     * Applies the specified FrameGraph to the scene, or clears the active frame graph when null.
+     * Call this from a derived class after constructing and building a FrameGraph.
+     *
+     * Optionally accepts an array of mesh filter predicates. For each predicate, the viewer
+     * maintains a filtered list of scene meshes and calls {@link _onObjectListsUpdated} with all
+     * lists whenever the active model changes. The method is also called immediately on this call
+     * so the caller can perform initial wiring without a separate code path.
+     *
+     * @param frameGraph The FrameGraph to activate, or null to revert to default rendering.
+     * @param filters Optional array of predicates — one per ObjectList input block to populate.
+     */
+    protected _setActiveFrameGraph(frameGraph: Nullable<FrameGraph>, filters: ReadonlyArray<(mesh: AbstractMesh) => boolean> = []): void {
+        // Tear down any existing object-list tracking.
+        this.onModelChanged.remove(this._objectListModelChangedObserver);
+        this._objectListModelChangedObserver = null;
+        this._objectListFilters = [];
+
+        this._scene.frameGraph = frameGraph;
+
+        // Always re-evaluate SSAO: tear it down when a frame graph is active,
+        // rebuild it when the frame graph is cleared.
+        this._updateSSAOPipeline();
+
+        if (!frameGraph) {
+            return;
+        }
+
+        this._objectListFilters = filters;
+
+        const notify = () => {
+            this._onObjectListsUpdated(this._objectListFilters.map((filter) => this._scene.meshes.filter(filter)));
+        };
+
+        // Fire immediately so the caller can wire up ObjectList blocks in one place.
+        notify();
+
+        // Re-fire after every model change so lists stay current as models are swapped.
+        this._objectListModelChangedObserver = this.onModelChanged.add(notify);
     }
 
     /**
@@ -1145,7 +1203,6 @@ export class Viewer extends ViewerBase implements IDisposable, IViewer {
                     transparencyAsCoverage: true,
                     useOpenPBR: (options as ViewerLoadModelOptions | undefined)?.useOpenPBR ?? this._options?.useOpenPBR ?? DefaultViewerOptions.useOpenPBR,
                     extensionOptions: {
-                        // eslint-disable-next-line @typescript-eslint/naming-convention
                         KHR_materials_variants: {
                             // Capture the material variants controller when it is loaded.
                             onLoaded: onMaterialVariantsLoaded,
@@ -1421,7 +1478,6 @@ export class Viewer extends ViewerBase implements IDisposable, IViewer {
     }
 
     private async _updateEnvShadow(abortSignal?: AbortSignal) {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const [{ ShaderMaterial }, { ShaderLanguage }, { CreateDisc }, { IblShadowsRenderPipeline }] = await Promise.all([
             import("core/Materials/shaderMaterial"),
             import("core/Materials/shaderLanguage"),
@@ -1595,7 +1651,6 @@ export class Viewer extends ViewerBase implements IDisposable, IViewer {
     }
 
     private async _updateShadowMap(abortSignal?: AbortSignal) {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const [{ CreateDisc }, { RenderTargetTexture }, { ShadowGenerator }, { IblCdfGenerator }] = await Promise.all([
             import("core/Meshes/Builders/discBuilder"),
             import("core/Materials/Textures/renderTargetTexture"),
@@ -2185,6 +2240,8 @@ export class Viewer extends ViewerBase implements IDisposable, IViewer {
         this._beforeRenderObserver?.remove();
         this._snapshotHelper?.dispose();
 
+        this.onModelChanged.remove(this._objectListModelChangedObserver);
+
         // Base disposes observables and sets _isDisposed = true
         super.dispose();
     }
@@ -2340,6 +2397,7 @@ export class Viewer extends ViewerBase implements IDisposable, IViewer {
         // 5. The environment shadows are not yet in a ready state.
         // 6. The SSAO pipeline is not yet in a ready state.
         // 7. At least one model should render (playing animations).
+        // 8. A model (or other asset) load is in flight.
         return (
             !this._autoSuspendRendering ||
             this._sceneMutated ||
@@ -2347,7 +2405,8 @@ export class Viewer extends ViewerBase implements IDisposable, IViewer {
             this._shadowState.normal?.shouldRender ||
             this._shadowState.high?.shouldRender ||
             this._ssaoPipeline?.isReady() === false ||
-            this._loadedModelsBacking.some((model) => model._shouldRender())
+            this._loadedModelsBacking.some((model) => model._shouldRender()) ||
+            this._loadOperations.size > 0
         );
     }
 


### PR DESCRIPTION
In my BabylonNative fork with a custom wgpu-native renderer, I need to drive 90+fps rendering on MacBook Pro, Apple TV, iPhone 16, (and soon) Meta Quest 3 and Apple Vision Pro. To override the defaults in that custom NativeEngine, I need this seam to be hoisted up in the inheritance chain.

This should also help us with our headless unit tests in NullEngine as well, in terms of making them run in a shorter amount of time, by giving us more control over ticks. if we figure out a good pattern on that, we'll push it our to our babylon-testing-library package.

Validation:
- npx vitest run --project=unit packages/dev/core/test/unit/Engines/thinEngine.test.ts packages/dev/core/test/unit/Engines/nullEngine.test.ts
- npx eslint --quiet packages/dev/core/src/Engines/abstractEngine.pure.ts packages/dev/core/src/Engines/engine.pure.ts
- integrated into my BabylonNative fork and was able to achieve 120fps on numerous devices with a device-optimzied rAF implementation.

 full lint still fails on an untouched inspector-v2 promise rejection lint issue on current master.