### PR TITLE
Fix KTX noMipmap flip for compressed sRGB mipmaps

### DIFF
--- a/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -83,6 +83,15 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
         const engine = texture.getEngine();
         const ktx = new KhronosTextureContainer(data, 6);
 
+        const mappedFormat = MapSRGBToLinear(ktx.glInternalFormat);
+        if (mappedFormat) {
+            texture.format = mappedFormat;
+            texture._useSRGBBuffer = texture.getEngine()._getUseSRGBBuffer(true, !texture.generateMipMaps);
+            texture._gammaSpace = true;
+        } else {
+            texture.format = ktx.glInternalFormat;
+        }
+
         const loadMipmap = ktx.numberOfMipmapLevels > 1 && texture.generateMipMaps;
 
         engine._unpackFlipY(true);
@@ -123,7 +132,7 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
             const mappedFormat = MapSRGBToLinear(ktx.glInternalFormat);
             if (mappedFormat) {
                 texture.format = mappedFormat;
-                texture._useSRGBBuffer = texture.getEngine()._getUseSRGBBuffer(true, texture.generateMipMaps);
+                texture._useSRGBBuffer = texture.getEngine()._getUseSRGBBuffer(true, !texture.generateMipMaps);
                 texture._gammaSpace = true;
             } else {
                 texture.format = ktx.glInternalFormat;

--- a/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts
@@ -84,9 +84,9 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
         const ktx = new KhronosTextureContainer(data, 6);
 
         const mappedFormat = MapSRGBToLinear(ktx.glInternalFormat);
-        if (mappedFormat) {
+        if (mappedFormat !== null) {
             texture.format = mappedFormat;
-            texture._useSRGBBuffer = texture.getEngine()._getUseSRGBBuffer(true, !texture.generateMipMaps);
+            texture._useSRGBBuffer = engine._getUseSRGBBuffer(true, !texture.generateMipMaps);
             texture._gammaSpace = true;
         } else {
             texture.format = ktx.glInternalFormat;
@@ -130,7 +130,7 @@ export class _KTXTextureLoader implements IInternalTextureLoader {
             const ktx = new KhronosTextureContainer(data, 1);
 
             const mappedFormat = MapSRGBToLinear(ktx.glInternalFormat);
-            if (mappedFormat) {
+            if (mappedFormat !== null) {
                 texture.format = mappedFormat;
                 texture._useSRGBBuffer = texture.getEngine()._getUseSRGBBuffer(true, !texture.generateMipMaps);
                 texture._gammaSpace = true;

--- a/packages/dev/core/test/unit/Materials/Textures/ktxTextureLoader.test.ts
+++ b/packages/dev/core/test/unit/Materials/Textures/ktxTextureLoader.test.ts
@@ -6,6 +6,7 @@ import { InternalTexture, InternalTextureSource } from "core/Materials/Textures/
 import { _KTXTextureLoader } from "core/Materials/Textures/Loaders/ktxTextureLoader";
 
 const KTX_IDENTIFIER = [0xab, 0x4b, 0x54, 0x58, 0x20, 0x31, 0x31, 0xbb, 0x0d, 0x0a, 0x1a, 0x0a];
+const GL_RGBA = 0x1908;
 
 function createKtx1Data(glInternalFormat: number, faceCount = 1): Uint8Array {
     const imageSize = 16;
@@ -18,7 +19,7 @@ function createKtx1Data(glInternalFormat: number, faceCount = 1): Uint8Array {
     header.setUint32(8, 1, true); // glTypeSize
     header.setUint32(12, 0, true); // glFormat
     header.setUint32(16, glInternalFormat, true);
-    header.setUint32(20, Constants.TEXTUREFORMAT_RGBA, true);
+    header.setUint32(20, GL_RGBA, true);
     header.setUint32(24, 4, true); // pixelWidth
     header.setUint32(28, 4, true); // pixelHeight
     header.setUint32(32, 0, true); // pixelDepth

--- a/packages/dev/core/test/unit/Materials/Textures/ktxTextureLoader.test.ts
+++ b/packages/dev/core/test/unit/Materials/Textures/ktxTextureLoader.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Constants } from "core/Engines/constants";
+import { NullEngine } from "core/Engines/nullEngine";
+import { InternalTexture, InternalTextureSource } from "core/Materials/Textures/internalTexture";
+import { _KTXTextureLoader } from "core/Materials/Textures/Loaders/ktxTextureLoader";
+
+const KTX_IDENTIFIER = [0xab, 0x4b, 0x54, 0x58, 0x20, 0x31, 0x31, 0xbb, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function createKtx1Data(glInternalFormat: number, faceCount = 1): Uint8Array {
+    const imageSize = 16;
+    const data = new Uint8Array(68 + imageSize * faceCount);
+    data.set(KTX_IDENTIFIER, 0);
+
+    const header = new DataView(data.buffer, 12);
+    header.setUint32(0, 0x04030201, true); // endianness
+    header.setUint32(4, 0, true); // glType: compressed texture
+    header.setUint32(8, 1, true); // glTypeSize
+    header.setUint32(12, 0, true); // glFormat
+    header.setUint32(16, glInternalFormat, true);
+    header.setUint32(20, Constants.TEXTUREFORMAT_RGBA, true);
+    header.setUint32(24, 4, true); // pixelWidth
+    header.setUint32(28, 4, true); // pixelHeight
+    header.setUint32(32, 0, true); // pixelDepth
+    header.setUint32(36, 0, true); // numberOfArrayElements
+    header.setUint32(40, faceCount, true); // numberOfFaces
+    header.setUint32(44, 1, true); // numberOfMipmapLevels
+    header.setUint32(48, 0, true); // bytesOfKeyValueData
+    header.setUint32(52, imageSize, true); // level imageSize
+
+    return data;
+}
+
+describe("KTX texture loader", () => {
+    it.each([true, false])("preserves compressed sRGB metadata for 2D textures with generateMipMaps=%s", (generateMipMaps) => {
+        const engine = new NullEngine();
+        const texture = new InternalTexture(engine, InternalTextureSource.Url);
+        texture.generateMipMaps = generateMipMaps;
+        texture.invertY = false;
+        const getUseSRGBBufferSpy = vi.spyOn(engine, "_getUseSRGBBuffer").mockReturnValue(true);
+
+        new _KTXTextureLoader().loadData(createKtx1Data(Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR), texture, (width, height, loadMipmap, isCompressed) => {
+            expect(width).toBe(4);
+            expect(height).toBe(4);
+            expect(loadMipmap).toBe(generateMipMaps);
+            expect(isCompressed).toBe(true);
+            expect(texture.format).toBe(Constants.TEXTUREFORMAT_COMPRESSED_RGBA_ASTC_4x4);
+            expect(texture._gammaSpace).toBe(true);
+            expect(texture._useSRGBBuffer).toBe(true);
+        });
+
+        expect(getUseSRGBBufferSpy).toHaveBeenCalledWith(true, !generateMipMaps);
+        engine.dispose();
+    });
+
+    it.each([true, false])("preserves compressed sRGB metadata for cube textures with generateMipMaps=%s", (generateMipMaps) => {
+        const engine = new NullEngine();
+        const texture = new InternalTexture(engine, InternalTextureSource.Cube);
+        texture.generateMipMaps = generateMipMaps;
+        texture.invertY = false;
+        const getUseSRGBBufferSpy = vi.spyOn(engine, "_getUseSRGBBuffer").mockReturnValue(true);
+        vi.spyOn(engine, "_uploadCompressedDataToTextureDirectly").mockImplementation(() => {});
+        vi.spyOn(engine, "_unpackFlipY").mockImplementation(() => {});
+        vi.spyOn(engine, "_setCubeMapTextureParams").mockImplementation(() => {});
+        const onLoad = vi.fn();
+
+        new _KTXTextureLoader().loadCubeData(createKtx1Data(Constants.TEXTUREFORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR, 6), texture, false, onLoad);
+
+        expect(getUseSRGBBufferSpy).toHaveBeenCalledWith(true, !generateMipMaps);
+        expect(texture.format).toBe(Constants.TEXTUREFORMAT_COMPRESSED_RGBA_ASTC_4x4);
+        expect(texture._gammaSpace).toBe(true);
+        expect(texture._useSRGBBuffer).toBe(true);
+        expect(onLoad).toHaveBeenCalledTimes(1);
+        engine.dispose();
+    });
+});


### PR DESCRIPTION
## Summary
- Preserve compressed KTX1 sRGB/gamma intent on the Babylon internal texture while uploading the matching linear compressed GPU format.
- Fix the old KTX1 path passing `generateMipMaps` where `_getUseSRGBBuffer` expects `noMipmap`, which mis-decided the sRGB buffer exactly when mipmaps are present.
- Add focused unit coverage for sRGB ASTC KTX input and assert `_getUseSRGBBuffer(true, !generateMipMaps)` for 2D and cube paths.

## Why this is the right generalized fix
We ran into this while converting the Hill Valley portal scene to a GLTF/GLB-backed mobile asset set for BabylonNative NativeXR/WebGPU. The mobile package uses GPU-native compressed textures for iPhone XS (iOS 18) and iPhone 12 (iOS 26), and the previous KTX1 path treated the compressed internal format as a raw GPU upload format only. That lost the source texture's sRGB intent, so material colors and emissive/reflective balance could diverge when using compressed assets.

The fix keeps the engine upload format browser/GPU-compatible by mapping compressed sRGB formats to their linear compressed counterparts for upload, but preserves the texture's gamma/sRGB metadata on the `InternalTexture`. That matches how the rest of Babylon reasons about color-space intent without asking renderers to upload unsupported sRGB compressed formats directly.

The no-mipmap polarity fix is part of the same correctness path: `_getUseSRGBBuffer` takes a `noMipmap` argument, so passing `generateMipMaps` inverted the decision and could select the wrong sRGB buffer behavior exactly for mipmapped compressed KTX textures.

## Validation
- `npx vitest run --project=unit packages/dev/core/test/unit/Materials/Textures/ktxTextureLoader.test.ts`
- `npx eslint packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts packages/dev/core/test/unit/Materials/Textures/ktxTextureLoader.test.ts --quiet --cache`
- `npx prettier --check packages/dev/core/src/Materials/Textures/Loaders/ktxTextureLoader.ts packages/dev/core/test/unit/Materials/Textures/ktxTextureLoader.test.ts`

The underlying issue was also observed during BabylonNative Hill Valley portal validation on physical iPhone XS and iPhone 12 devices with the mobile-optimized GLB/KTX asset package, and this PR fixes the on-device issue.
